### PR TITLE
FLW-579 iOS: Elected validators in Era service

### DIFF
--- a/fearless.xcodeproj/project.pbxproj
+++ b/fearless.xcodeproj/project.pbxproj
@@ -405,6 +405,12 @@
 		84893C0324DA8641008F6A3F /* AccountCreationRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84893C0224DA8641008F6A3F /* AccountCreationRequest.swift */; };
 		84893C0524DA8663008F6A3F /* AccountCreationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84893C0424DA8663008F6A3F /* AccountCreationError.swift */; };
 		84893C0724DA890F008F6A3F /* CommonError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84893C0624DA890F008F6A3F /* CommonError.swift */; };
+		848FFE6625E6742400652AA5 /* EraValidatorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848FFE6525E6742400652AA5 /* EraValidatorService.swift */; };
+		848FFE8325E686C200652AA5 /* StorageDecodingOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848FFE8225E686C200652AA5 /* StorageDecodingOperation.swift */; };
+		848FFE8B25E69A6000652AA5 /* EraValidatorServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848FFE8A25E69A6000652AA5 /* EraValidatorServiceProtocol.swift */; };
+		848FFE9025E6CF4300652AA5 /* StorageKeyEncodingOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848FFE8F25E6CF4300652AA5 /* StorageKeyEncodingOperation.swift */; };
+		848FFE9525E6DF2200652AA5 /* PagedKeysRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848FFE9425E6DF2200652AA5 /* PagedKeysRequest.swift */; };
+		848FFE9A25E6E0E400652AA5 /* ValidatorExposure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848FFE9925E6E0E400652AA5 /* ValidatorExposure.swift */; };
 		849013AC24A80984008F705E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849013AB24A80984008F705E /* AppDelegate.swift */; };
 		849013B524A80986008F705E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 849013B424A80986008F705E /* Assets.xcassets */; };
 		849013B824A80986008F705E /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 849013B624A80986008F705E /* LaunchScreen.storyboard */; };
@@ -625,6 +631,9 @@
 		84EBC55224F660A700459D15 /* EventProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84EBC54724F660A700459D15 /* EventProtocols.swift */; };
 		84EBC55B24F660F500459D15 /* SelectedAccountChanged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84EBC55A24F660F500459D15 /* SelectedAccountChanged.swift */; };
 		84EBC55F24F71D6A00459D15 /* UITableViewCell+ReorderColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84EBC55E24F71D6A00459D15 /* UITableViewCell+ReorderColor.swift */; };
+		84F2FEFA25E797E8008338D5 /* StorageRequestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F2FEF925E797E8008338D5 /* StorageRequestFactory.swift */; };
+		84F2FEFF25E7ADE7008338D5 /* ValidatorPrefs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F2FEFE25E7ADE7008338D5 /* ValidatorPrefs.swift */; };
+		84F2FF0725E7AF8F008338D5 /* EraValidatorInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F2FF0625E7AF8F008338D5 /* EraValidatorInfo.swift */; };
 		84F4386125D9A83100AEDA56 /* TimeInterval+Time.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F4386025D9A83100AEDA56 /* TimeInterval+Time.swift */; };
 		84F4386625D9B8C600AEDA56 /* TypeRegistryPrepared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F4386525D9B8C600AEDA56 /* TypeRegistryPrepared.swift */; };
 		84F4386B25D9B9EA00AEDA56 /* RuntimeRegistryFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F4386A25D9B9EA00AEDA56 /* RuntimeRegistryFacade.swift */; };
@@ -646,7 +655,7 @@
 		84F4A9182550331D000CF0A3 /* ExportOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F4A9172550331D000CF0A3 /* ExportOption.swift */; };
 		84F4A93725504E6E000CF0A3 /* AccountInfoExportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F4A93625504E6E000CF0A3 /* AccountInfoExportTests.swift */; };
 		84F4A9A42551A8F3000CF0A3 /* AccountExportPasswordError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F4A9A32551A8F3000CF0A3 /* AccountExportPasswordError.swift */; };
-		84F98D8A25E3DD3F0040418E /* RuntimeKnown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F98D8925E3DD3F0040418E /* RuntimeKnown.swift */; };
+		84F98D8A25E3DD3F0040418E /* StorageCodingPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F98D8925E3DD3F0040418E /* StorageCodingPath.swift */; };
 		84F98D9625E3E2B10040418E /* InMemoryDataProviderRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F98D9525E3E2B10040418E /* InMemoryDataProviderRepository.swift */; };
 		84FAB0632542C8D600319F74 /* ContactItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FAB0622542C8D600319F74 /* ContactItem.swift */; };
 		84FAB0652542CA4200319F74 /* CDContactItem+CoreDataDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FAB0642542CA4200319F74 /* CDContactItem+CoreDataDecodable.swift */; };
@@ -1162,6 +1171,12 @@
 		84893C0224DA8641008F6A3F /* AccountCreationRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountCreationRequest.swift; sourceTree = "<group>"; };
 		84893C0424DA8663008F6A3F /* AccountCreationError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountCreationError.swift; sourceTree = "<group>"; };
 		84893C0624DA890F008F6A3F /* CommonError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonError.swift; sourceTree = "<group>"; };
+		848FFE6525E6742400652AA5 /* EraValidatorService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EraValidatorService.swift; sourceTree = "<group>"; };
+		848FFE8225E686C200652AA5 /* StorageDecodingOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageDecodingOperation.swift; sourceTree = "<group>"; };
+		848FFE8A25E69A6000652AA5 /* EraValidatorServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EraValidatorServiceProtocol.swift; sourceTree = "<group>"; };
+		848FFE8F25E6CF4300652AA5 /* StorageKeyEncodingOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageKeyEncodingOperation.swift; sourceTree = "<group>"; };
+		848FFE9425E6DF2200652AA5 /* PagedKeysRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagedKeysRequest.swift; sourceTree = "<group>"; };
+		848FFE9925E6E0E400652AA5 /* ValidatorExposure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidatorExposure.swift; sourceTree = "<group>"; };
 		849013A824A80984008F705E /* fearless.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = fearless.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		849013AB24A80984008F705E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		849013B424A80986008F705E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -1400,6 +1415,9 @@
 		84EBC54724F660A700459D15 /* EventProtocols.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventProtocols.swift; sourceTree = "<group>"; };
 		84EBC55A24F660F500459D15 /* SelectedAccountChanged.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedAccountChanged.swift; sourceTree = "<group>"; };
 		84EBC55E24F71D6A00459D15 /* UITableViewCell+ReorderColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+ReorderColor.swift"; sourceTree = "<group>"; };
+		84F2FEF925E797E8008338D5 /* StorageRequestFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageRequestFactory.swift; sourceTree = "<group>"; };
+		84F2FEFE25E7ADE7008338D5 /* ValidatorPrefs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidatorPrefs.swift; sourceTree = "<group>"; };
+		84F2FF0625E7AF8F008338D5 /* EraValidatorInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EraValidatorInfo.swift; sourceTree = "<group>"; };
 		84F4386025D9A83100AEDA56 /* TimeInterval+Time.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimeInterval+Time.swift"; sourceTree = "<group>"; };
 		84F4386525D9B8C600AEDA56 /* TypeRegistryPrepared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeRegistryPrepared.swift; sourceTree = "<group>"; };
 		84F4386A25D9B9EA00AEDA56 /* RuntimeRegistryFacade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeRegistryFacade.swift; sourceTree = "<group>"; };
@@ -1421,7 +1439,7 @@
 		84F4A9172550331D000CF0A3 /* ExportOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportOption.swift; sourceTree = "<group>"; };
 		84F4A93625504E6E000CF0A3 /* AccountInfoExportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountInfoExportTests.swift; sourceTree = "<group>"; };
 		84F4A9A32551A8F3000CF0A3 /* AccountExportPasswordError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountExportPasswordError.swift; sourceTree = "<group>"; };
-		84F98D8925E3DD3F0040418E /* RuntimeKnown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeKnown.swift; sourceTree = "<group>"; };
+		84F98D8925E3DD3F0040418E /* StorageCodingPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageCodingPath.swift; sourceTree = "<group>"; };
 		84F98D9525E3E2B10040418E /* InMemoryDataProviderRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InMemoryDataProviderRepository.swift; sourceTree = "<group>"; };
 		84FAB0622542C8D600319F74 /* ContactItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactItem.swift; sourceTree = "<group>"; };
 		84FAB0642542CA4200319F74 /* CDContactItem+CoreDataDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CDContactItem+CoreDataDecodable.swift"; sourceTree = "<group>"; };
@@ -1860,6 +1878,7 @@
 		84155DE8253980D700A27058 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				848FFE6425E670CE00652AA5 /* EraValidatorsService */,
 				845BB8B625E4464D00E5FCDC /* ExtrinsicService */,
 				2AB7A7FD25CD0E3E00767D87 /* GitHubPhishingService */,
 				84452F2925D5B81800F47EC5 /* RuntimeRegistryService */,
@@ -2171,7 +2190,9 @@
 				84DF21A62534D031005454AE /* AccountId.swift */,
 				849E0D1725D01FD000B33506 /* Multiaddress.swift */,
 				8463A73725E3AA47003B8160 /* DyAccountInfo.swift */,
-				84F98D8925E3DD3F0040418E /* RuntimeKnown.swift */,
+				84F98D8925E3DD3F0040418E /* StorageCodingPath.swift */,
+				848FFE9925E6E0E400652AA5 /* ValidatorExposure.swift */,
+				84F2FEFE25E7ADE7008338D5 /* ValidatorPrefs.swift */,
 			);
 			path = Types;
 			sourceTree = "<group>";
@@ -2587,6 +2608,15 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
+		848FFE6425E670CE00652AA5 /* EraValidatorsService */ = {
+			isa = PBXGroup;
+			children = (
+				848FFE6525E6742400652AA5 /* EraValidatorService.swift */,
+				848FFE8A25E69A6000652AA5 /* EraValidatorServiceProtocol.swift */,
+			);
+			path = EraValidatorsService;
+			sourceTree = "<group>";
+		};
 		8490139F24A80984008F705E = {
 			isa = PBXGroup;
 			children = (
@@ -2779,6 +2809,7 @@
 				8401620525E130D60087A5F3 /* ViewAction.swift */,
 				845BB8D525E461FC00E5FCDC /* RewardDestination.swift */,
 				845BB8DA25E462B100E5FCDC /* SubstrateConstansts.swift */,
+				84F2FF0625E7AF8F008338D5 /* EraValidatorInfo.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -2955,6 +2986,9 @@
 				8490148324AA27C1008F705E /* OperationManagerFacade.swift */,
 				84A2C90324E07F400020D3B7 /* AccountOperationFactoryError.swift */,
 				843910C8253F591D00E3C217 /* ScaleDecoderOperation.swift */,
+				848FFE8225E686C200652AA5 /* StorageDecodingOperation.swift */,
+				848FFE8F25E6CF4300652AA5 /* StorageKeyEncodingOperation.swift */,
+				84F2FEF925E797E8008338D5 /* StorageRequestFactory.swift */,
 			);
 			path = Operation;
 			sourceTree = "<group>";
@@ -3356,6 +3390,7 @@
 				84FD3DB42540ED0900A234E3 /* Block.swift */,
 				84C4C2D0255CA9210045B582 /* Health.swift */,
 				84F4393925DAC48D00AEDA56 /* JSONRPCAliases.swift */,
+				848FFE9425E6DF2200652AA5 /* PagedKeysRequest.swift */,
 			);
 			path = JSONRPC;
 			sourceTree = "<group>";
@@ -4286,6 +4321,7 @@
 				8409C264252210A70049B5C8 /* WalletDisplayAmountView.swift in Sources */,
 				842876A824AE049B00D91AD8 /* SelectionListViewController.swift in Sources */,
 				84CAF52224BDB94700F4C295 /* JSONRPCEngine.swift in Sources */,
+				848FFE9025E6CF4300652AA5 /* StorageKeyEncodingOperation.swift in Sources */,
 				8443FDB6255540570092893D /* ExportMnemonicData.swift in Sources */,
 				84893C0724DA890F008F6A3F /* CommonError.swift in Sources */,
 				843910B0253ED36C00E3C217 /* ChainStorageItem.swift in Sources */,
@@ -4336,6 +4372,7 @@
 				84CE69DD2565BB6400559427 /* AboutViewModel.swift in Sources */,
 				84DF21B32536E666005454AE /* TransferChangeHandling.swift in Sources */,
 				849E0CE525D01AEE00B33506 /* ExtrinsicFactory.swift in Sources */,
+				84F2FEFF25E7ADE7008338D5 /* ValidatorPrefs.swift in Sources */,
 				84A259F82555C8C9001E91BC /* CryptoType+Keystore.swift in Sources */,
 				8467FD4324ED5F46005D486C /* ProfileSectionTableViewCell.swift in Sources */,
 				84452F9D25D6768000F47EC5 /* RuntimeMetadataItem.swift in Sources */,
@@ -4360,7 +4397,7 @@
 				84FD3DBE25419FD900A234E3 /* TransactionDetailsConfigurator.swift in Sources */,
 				84754C942511EB2A00854599 /* ManagedConnectionItem.swift in Sources */,
 				849014B924AA87E3008F705E /* PinSetupViewController.swift in Sources */,
-				84F98D8A25E3DD3F0040418E /* RuntimeKnown.swift in Sources */,
+				84F98D8A25E3DD3F0040418E /* StorageCodingPath.swift in Sources */,
 				84F43C0F25DF016600AEDA56 /* DispatchQueueHelper.swift in Sources */,
 				8490147824A94A37008F705E /* RootPresenterFactory.swift in Sources */,
 				849014C224AA87E4008F705E /* LocalAuthPresenter.swift in Sources */,
@@ -4420,6 +4457,7 @@
 				8463A72D25E3A8E1003B8160 /* ChainStorageDecodedItem.swift in Sources */,
 				840882B4251413D000177E20 /* ConnectionMainWireframe.swift in Sources */,
 				84265E002523C410005EEE2D /* TransferDefinitionFactory.swift in Sources */,
+				848FFE9525E6DF2200652AA5 /* PagedKeysRequest.swift in Sources */,
 				8428766B24ADF51D00D91AD8 /* UIViewController+Modal.swift in Sources */,
 				8494D85E25246E9A00614D8F /* WalletTokenViewModel.swift in Sources */,
 				2AB7A7FF25CD0E8000767D87 /* GitHubPhishingAPIService.swift in Sources */,
@@ -4460,6 +4498,7 @@
 				8494D8702525321700614D8F /* SubscanDefinitions.swift in Sources */,
 				84D8F16124D8193200AF43E9 /* IconWithTitleTableViewCell.swift in Sources */,
 				8428763824AD67E300D91AD8 /* JSONRPCData.swift in Sources */,
+				848FFE8B25E69A6000652AA5 /* EraValidatorServiceProtocol.swift in Sources */,
 				840882BF2514B3FE00177E20 /* ConnectionAccountConfirmInteractor.swift in Sources */,
 				842876A624AE049B00D91AD8 /* SelectableViewModelProtocol.swift in Sources */,
 				8428765D24ADDE0200D91AD8 /* ProfileInteractor.swift in Sources */,
@@ -4513,6 +4552,7 @@
 				8428769324AE046300D91AD8 /* AboutWireframe.swift in Sources */,
 				84754CA22513DB8800854599 /* EmptyAccountIcon.swift in Sources */,
 				84CE69922565244700559427 /* WalletAccountOpenCommand.swift in Sources */,
+				84F2FEFA25E797E8008338D5 /* StorageRequestFactory.swift in Sources */,
 				8468B87424F63D4B00B76BC6 /* AddConfirmationWireframe.swift in Sources */,
 				8428763A24AD6AF000D91AD8 /* JSONRPCInfo.swift in Sources */,
 				849014BB24AA87E4008F705E /* PinSetupWireframe.swift in Sources */,
@@ -4526,6 +4566,7 @@
 				8494D8782525343500614D8F /* SubscanOperationFactory.swift in Sources */,
 				84754C852510A1A400854599 /* ModalAlertPresenting.swift in Sources */,
 				8463A6F925E2F82E003B8160 /* CDSingleValue+CoreDataCodable.swift in Sources */,
+				848FFE6625E6742400652AA5 /* EraValidatorService.swift in Sources */,
 				846AF8402525B94D00868F37 /* WalletNetworkFacade+Protocol.swift in Sources */,
 				8468B86C24F63CEF00B76BC6 /* AddAccountConfirmInteractor.swift in Sources */,
 				84754C8E2511539E00854599 /* ManagedConnectionViewModel.swift in Sources */,
@@ -4580,6 +4621,7 @@
 				8475AE34258B934F00B058F3 /* TransferValidatingError.swift in Sources */,
 				8494D8552524633300614D8F /* WalletTransferTokenView.swift in Sources */,
 				8490142E24A935FE008F705E /* LoadableViewProtocol.swift in Sources */,
+				84F2FF0725E7AF8F008338D5 /* EraValidatorInfo.swift in Sources */,
 				8490152324ABC77E008F705E /* WalletAssetViewModel.swift in Sources */,
 				84DA3B1924C8200E00B5E27F /* ConnectionItem+Default.swift in Sources */,
 				84D331AF2519E8080078D044 /* TriangularedView+Style.swift in Sources */,
@@ -4591,6 +4633,7 @@
 				8460519425546E7100A1F0B4 /* Chain+ViewModel.swift in Sources */,
 				DAB29F2A9C864D7FCF1AF934 /* UsernameSetupProtocols.swift in Sources */,
 				841937832544455C00CFA50C /* AccountShareFactory.swift in Sources */,
+				848FFE8325E686C200652AA5 /* StorageDecodingOperation.swift in Sources */,
 				8488ECDF258CE118004591CC /* PurchaseCompleted.swift in Sources */,
 				843910C3253F39B100E3C217 /* WalletNetworkFacade+Storage.swift in Sources */,
 				7489BDA1D23D8DF73E7EB9BC /* UsernameSetupWireframe.swift in Sources */,
@@ -4758,6 +4801,7 @@
 				4C74355397068A023BBEDDB5 /* CommingSoonViewFactory.swift in Sources */,
 				99A4B2A357ADEA45EFF515A5 /* AccountExportPasswordProtocols.swift in Sources */,
 				64B508A1A3D820AA8DBCFAA3 /* AccountExportPasswordWireframe.swift in Sources */,
+				848FFE9A25E6E0E400652AA5 /* ValidatorExposure.swift in Sources */,
 				5DDD2206DF795CF205610455 /* AccountExportPasswordPresenter.swift in Sources */,
 				800FCAF66DC8A24020D16A9C /* AccountExportPasswordInteractor.swift in Sources */,
 				7C93FA82996A426E7B8CA06E /* AccountExportPasswordViewController.swift in Sources */,

--- a/fearless.xcodeproj/project.pbxproj
+++ b/fearless.xcodeproj/project.pbxproj
@@ -535,6 +535,7 @@
 		84A2C90724E09DC20020D3B7 /* AccountOperationFactoryError+Presentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A2C90624E09DC20020D3B7 /* AccountOperationFactoryError+Presentable.swift */; };
 		84A2C90C24E192F50020D3B7 /* ShakeAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A2C90B24E192F50020D3B7 /* ShakeAnimator.swift */; };
 		84A2CD5325685A4100A9FB0D /* WalletHistoryViewFactoryOverriding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A2CD5225685A4100A9FB0D /* WalletHistoryViewFactoryOverriding.swift */; };
+		84BE207825E7D62100B4748C /* ActiveEraInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BE207725E7D62100B4748C /* ActiveEraInfo.swift */; };
 		84BEE059255F4D5700D05EB3 /* AccountImportPreferredInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BEE058255F4D5700D05EB3 /* AccountImportPreferredInfo.swift */; };
 		84BEE0F02562897100D05EB3 /* AccountImportJsonFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BEE0EF2562897100D05EB3 /* AccountImportJsonFactory.swift */; };
 		84BEE22325646AC000D05EB3 /* SelectedUsernameChanged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BEE22225646ABF00D05EB3 /* SelectedUsernameChanged.swift */; };
@@ -634,6 +635,7 @@
 		84F2FEFA25E797E8008338D5 /* StorageRequestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F2FEF925E797E8008338D5 /* StorageRequestFactory.swift */; };
 		84F2FEFF25E7ADE7008338D5 /* ValidatorPrefs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F2FEFE25E7ADE7008338D5 /* ValidatorPrefs.swift */; };
 		84F2FF0725E7AF8F008338D5 /* EraValidatorInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F2FF0625E7AF8F008338D5 /* EraValidatorInfo.swift */; };
+		84F2FF0F25E7D059008338D5 /* EraValidatorFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F2FF0E25E7D059008338D5 /* EraValidatorFactory.swift */; };
 		84F4386125D9A83100AEDA56 /* TimeInterval+Time.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F4386025D9A83100AEDA56 /* TimeInterval+Time.swift */; };
 		84F4386625D9B8C600AEDA56 /* TypeRegistryPrepared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F4386525D9B8C600AEDA56 /* TypeRegistryPrepared.swift */; };
 		84F4386B25D9B9EA00AEDA56 /* RuntimeRegistryFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F4386A25D9B9EA00AEDA56 /* RuntimeRegistryFacade.swift */; };
@@ -1311,6 +1313,7 @@
 		84A2C90624E09DC20020D3B7 /* AccountOperationFactoryError+Presentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AccountOperationFactoryError+Presentable.swift"; sourceTree = "<group>"; };
 		84A2C90B24E192F50020D3B7 /* ShakeAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShakeAnimator.swift; sourceTree = "<group>"; };
 		84A2CD5225685A4100A9FB0D /* WalletHistoryViewFactoryOverriding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletHistoryViewFactoryOverriding.swift; sourceTree = "<group>"; };
+		84BE207725E7D62100B4748C /* ActiveEraInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveEraInfo.swift; sourceTree = "<group>"; };
 		84BEE058255F4D5700D05EB3 /* AccountImportPreferredInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountImportPreferredInfo.swift; sourceTree = "<group>"; };
 		84BEE0EF2562897100D05EB3 /* AccountImportJsonFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountImportJsonFactory.swift; sourceTree = "<group>"; };
 		84BEE22225646ABF00D05EB3 /* SelectedUsernameChanged.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedUsernameChanged.swift; sourceTree = "<group>"; };
@@ -1418,6 +1421,7 @@
 		84F2FEF925E797E8008338D5 /* StorageRequestFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageRequestFactory.swift; sourceTree = "<group>"; };
 		84F2FEFE25E7ADE7008338D5 /* ValidatorPrefs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidatorPrefs.swift; sourceTree = "<group>"; };
 		84F2FF0625E7AF8F008338D5 /* EraValidatorInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EraValidatorInfo.swift; sourceTree = "<group>"; };
+		84F2FF0E25E7D059008338D5 /* EraValidatorFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EraValidatorFactory.swift; sourceTree = "<group>"; };
 		84F4386025D9A83100AEDA56 /* TimeInterval+Time.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimeInterval+Time.swift"; sourceTree = "<group>"; };
 		84F4386525D9B8C600AEDA56 /* TypeRegistryPrepared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeRegistryPrepared.swift; sourceTree = "<group>"; };
 		84F4386A25D9B9EA00AEDA56 /* RuntimeRegistryFacade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeRegistryFacade.swift; sourceTree = "<group>"; };
@@ -2193,6 +2197,7 @@
 				84F98D8925E3DD3F0040418E /* StorageCodingPath.swift */,
 				848FFE9925E6E0E400652AA5 /* ValidatorExposure.swift */,
 				84F2FEFE25E7ADE7008338D5 /* ValidatorPrefs.swift */,
+				84BE207725E7D62100B4748C /* ActiveEraInfo.swift */,
 			);
 			path = Types;
 			sourceTree = "<group>";
@@ -2613,6 +2618,7 @@
 			children = (
 				848FFE6525E6742400652AA5 /* EraValidatorService.swift */,
 				848FFE8A25E69A6000652AA5 /* EraValidatorServiceProtocol.swift */,
+				84F2FF0E25E7D059008338D5 /* EraValidatorFactory.swift */,
 			);
 			path = EraValidatorsService;
 			sourceTree = "<group>";
@@ -4283,6 +4289,7 @@
 				84452FA525D679F200F47EC5 /* CDRuntimeMetadataItem+CoreDataCodable.swift in Sources */,
 				84D97ECF2521CA2F00F07405 /* WalletBaseTokenView.swift in Sources */,
 				8409C277252286760049B5C8 /* TransferConfirmAccessoryView.swift in Sources */,
+				84BE207825E7D62100B4748C /* ActiveEraInfo.swift in Sources */,
 				8490150324AB6C01008F705E /* WalletNetworkOperationFactory.swift in Sources */,
 				84364D5E252FD09100281F9A /* AssetDetailsViewModel.swift in Sources */,
 				845BB8C925E45D1500E5FCDC /* BondCall.swift in Sources */,
@@ -4414,6 +4421,7 @@
 				8401620B25E144D50087A5F3 /* AmountInputAccessoryView.swift in Sources */,
 				8490151324AB8A3A008F705E /* WalletEmptyStateDataSource.swift in Sources */,
 				84DF21AB25363C9F005454AE /* Chain+Info.swift in Sources */,
+				84F2FF0F25E7D059008338D5 /* EraValidatorFactory.swift in Sources */,
 				846A2C50252A063800731018 /* WalletSelectAccountCommandFactory.swift in Sources */,
 				8490147624A94A37008F705E /* RootInteractor.swift in Sources */,
 				849014C524AA890D008F705E /* UIFont+Style.swift in Sources */,

--- a/fearless.xcodeproj/project.pbxproj
+++ b/fearless.xcodeproj/project.pbxproj
@@ -538,6 +538,7 @@
 		84BE207825E7D62100B4748C /* ActiveEraInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BE207725E7D62100B4748C /* ActiveEraInfo.swift */; };
 		84BE209E25E85CCA00B4748C /* ServiceCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BE209D25E85CCA00B4748C /* ServiceCoordinator.swift */; };
 		84BE20A325E860DC00B4748C /* WebSocketServiceFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BE20A225E860DC00B4748C /* WebSocketServiceFactory.swift */; };
+		84BE20A825E8D93E00B4748C /* Data+StorageKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BE20A725E8D93E00B4748C /* Data+StorageKey.swift */; };
 		84BEE059255F4D5700D05EB3 /* AccountImportPreferredInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BEE058255F4D5700D05EB3 /* AccountImportPreferredInfo.swift */; };
 		84BEE0F02562897100D05EB3 /* AccountImportJsonFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BEE0EF2562897100D05EB3 /* AccountImportJsonFactory.swift */; };
 		84BEE22325646AC000D05EB3 /* SelectedUsernameChanged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BEE22225646ABF00D05EB3 /* SelectedUsernameChanged.swift */; };
@@ -1318,6 +1319,7 @@
 		84BE207725E7D62100B4748C /* ActiveEraInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveEraInfo.swift; sourceTree = "<group>"; };
 		84BE209D25E85CCA00B4748C /* ServiceCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceCoordinator.swift; sourceTree = "<group>"; };
 		84BE20A225E860DC00B4748C /* WebSocketServiceFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketServiceFactory.swift; sourceTree = "<group>"; };
+		84BE20A725E8D93E00B4748C /* Data+StorageKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+StorageKey.swift"; sourceTree = "<group>"; };
 		84BEE058255F4D5700D05EB3 /* AccountImportPreferredInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountImportPreferredInfo.swift; sourceTree = "<group>"; };
 		84BEE0EF2562897100D05EB3 /* AccountImportJsonFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountImportJsonFactory.swift; sourceTree = "<group>"; };
 		84BEE22225646ABF00D05EB3 /* SelectedUsernameChanged.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedUsernameChanged.swift; sourceTree = "<group>"; };
@@ -2967,6 +2969,7 @@
 				846A2C4425271F0100731018 /* DateFormatter.swift */,
 				846A2C4C2529FBB700731018 /* NSPredicate+Filter.swift */,
 				84F4386025D9A83100AEDA56 /* TimeInterval+Time.swift */,
+				84BE20A725E8D93E00B4748C /* Data+StorageKey.swift */,
 			);
 			path = Foundation;
 			sourceTree = "<group>";
@@ -4690,6 +4693,7 @@
 				84F4386625D9B8C600AEDA56 /* TypeRegistryPrepared.swift in Sources */,
 				84C7435B251DC504009576C6 /* WalletNetworkOperationFactory+Protocol.swift in Sources */,
 				843910C5253F561500E3C217 /* CompoundOperationWrapper+Result.swift in Sources */,
+				84BE20A825E8D93E00B4748C /* Data+StorageKey.swift in Sources */,
 				84EBC55224F660A700459D15 /* EventProtocols.swift in Sources */,
 				84C6801624D7036B00006BF5 /* SubtitleActionControl.swift in Sources */,
 				840DCBF125DFEE4800D45C6A /* AmountInputView.swift in Sources */,

--- a/fearless.xcodeproj/project.pbxproj
+++ b/fearless.xcodeproj/project.pbxproj
@@ -536,6 +536,8 @@
 		84A2C90C24E192F50020D3B7 /* ShakeAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A2C90B24E192F50020D3B7 /* ShakeAnimator.swift */; };
 		84A2CD5325685A4100A9FB0D /* WalletHistoryViewFactoryOverriding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A2CD5225685A4100A9FB0D /* WalletHistoryViewFactoryOverriding.swift */; };
 		84BE207825E7D62100B4748C /* ActiveEraInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BE207725E7D62100B4748C /* ActiveEraInfo.swift */; };
+		84BE209E25E85CCA00B4748C /* ServiceCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BE209D25E85CCA00B4748C /* ServiceCoordinator.swift */; };
+		84BE20A325E860DC00B4748C /* WebSocketServiceFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BE20A225E860DC00B4748C /* WebSocketServiceFactory.swift */; };
 		84BEE059255F4D5700D05EB3 /* AccountImportPreferredInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BEE058255F4D5700D05EB3 /* AccountImportPreferredInfo.swift */; };
 		84BEE0F02562897100D05EB3 /* AccountImportJsonFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BEE0EF2562897100D05EB3 /* AccountImportJsonFactory.swift */; };
 		84BEE22325646AC000D05EB3 /* SelectedUsernameChanged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BEE22225646ABF00D05EB3 /* SelectedUsernameChanged.swift */; };
@@ -1314,6 +1316,8 @@
 		84A2C90B24E192F50020D3B7 /* ShakeAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShakeAnimator.swift; sourceTree = "<group>"; };
 		84A2CD5225685A4100A9FB0D /* WalletHistoryViewFactoryOverriding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletHistoryViewFactoryOverriding.swift; sourceTree = "<group>"; };
 		84BE207725E7D62100B4748C /* ActiveEraInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveEraInfo.swift; sourceTree = "<group>"; };
+		84BE209D25E85CCA00B4748C /* ServiceCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceCoordinator.swift; sourceTree = "<group>"; };
+		84BE20A225E860DC00B4748C /* WebSocketServiceFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketServiceFactory.swift; sourceTree = "<group>"; };
 		84BEE058255F4D5700D05EB3 /* AccountImportPreferredInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountImportPreferredInfo.swift; sourceTree = "<group>"; };
 		84BEE0EF2562897100D05EB3 /* AccountImportJsonFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountImportJsonFactory.swift; sourceTree = "<group>"; };
 		84BEE22225646ABF00D05EB3 /* SelectedUsernameChanged.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedUsernameChanged.swift; sourceTree = "<group>"; };
@@ -1888,6 +1892,7 @@
 				84452F2925D5B81800F47EC5 /* RuntimeRegistryService */,
 				84155DE9253980E100A27058 /* WebSocketService */,
 				84155DEC2539817200A27058 /* ApplicationService.swift */,
+				84BE209D25E85CCA00B4748C /* ServiceCoordinator.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1901,6 +1906,7 @@
 				84155DF02539DC0300A27058 /* WebSocketServiceProtocol.swift */,
 				843910A7253E3AF600E3C217 /* WebSocketSubscriptionFactory.swift */,
 				843910A9253E3BAA00E3C217 /* WebSocketSubscriptionProtocols.swift */,
+				84BE20A225E860DC00B4748C /* WebSocketServiceFactory.swift */,
 			);
 			path = WebSocketService;
 			sourceTree = "<group>";
@@ -4381,6 +4387,7 @@
 				849E0CE525D01AEE00B33506 /* ExtrinsicFactory.swift in Sources */,
 				84F2FEFF25E7ADE7008338D5 /* ValidatorPrefs.swift in Sources */,
 				84A259F82555C8C9001E91BC /* CryptoType+Keystore.swift in Sources */,
+				84BE209E25E85CCA00B4748C /* ServiceCoordinator.swift in Sources */,
 				8467FD4324ED5F46005D486C /* ProfileSectionTableViewCell.swift in Sources */,
 				84452F9D25D6768000F47EC5 /* RuntimeMetadataItem.swift in Sources */,
 				84DA3B1624C81ECE00B5E27F /* AccountItem.swift in Sources */,
@@ -4646,6 +4653,7 @@
 				843910C3253F39B100E3C217 /* WalletNetworkFacade+Storage.swift in Sources */,
 				7489BDA1D23D8DF73E7EB9BC /* UsernameSetupWireframe.swift in Sources */,
 				3E480EEAF501AEB5D543506D /* UsernameSetupPresenter.swift in Sources */,
+				84BE20A325E860DC00B4748C /* WebSocketServiceFactory.swift in Sources */,
 				84F4387525D9C6EB00AEDA56 /* SubstrateDataProviderFactory.swift in Sources */,
 				84754CA02513D83E00854599 /* AccountPickerViewModel.swift in Sources */,
 				84D8F16D24D82C7E00AF43E9 /* ModalPickerConfiguration.swift in Sources */,

--- a/fearless/Common/DataProvider/SingleValueProviderFactory.swift
+++ b/fearless/Common/DataProvider/SingleValueProviderFactory.swift
@@ -75,7 +75,7 @@ extension SingleValueProviderFactory: SingleValueProviderFactoryProtocol {
         let storageIdFactory = try ChainStorageIdFactory(chain: addressType.chain)
 
         let remoteKey = try StorageKeyFactory().accountInfoKeyForId(accountId)
-        let localKey = try storageIdFactory.createIdentifier(for: remoteKey)
+        let localKey = storageIdFactory.createIdentifier(for: remoteKey)
 
         if let dataProvider = providers[localKey]?.target as? DataProvider<DecodedAccountInfo> {
             return dataProvider
@@ -91,8 +91,7 @@ extension SingleValueProviderFactory: SingleValueProviderFactoryProtocol {
         let trigger = DataProviderProxyTrigger()
         let source: StorageProviderSource<DyAccountInfo> =
             StorageProviderSource(itemIdentifier: localKey,
-                                  decodingModuleName: SystemModule.name,
-                                  decodingStorageName: SystemModule.account,
+                                  codingPath: .account,
                                   runtimeService: runtimeService,
                                   provider: streamableProvider,
                                   trigger: trigger)

--- a/fearless/Common/Extension/Foundation/Data+StorageKey.swift
+++ b/fearless/Common/Extension/Foundation/Data+StorageKey.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+extension Data {
+    func getAccountIdFromKey() -> Data { suffix(32) }
+}

--- a/fearless/Common/Extension/Foundation/NSPredicate+Filter.swift
+++ b/fearless/Common/Extension/Foundation/NSPredicate+Filter.swift
@@ -34,4 +34,8 @@ extension NSPredicate {
     static func filterStorageItemsBy(identifier: String) -> NSPredicate {
         return NSPredicate(format: "%K == %@", #keyPath(CDChainStorageItem.identifier), identifier)
     }
+
+    static func filterByIdPrefix(_ prefix: String) -> NSPredicate {
+        return NSPredicate(format: "%K BEGINSWITH %@", #keyPath(CDChainStorageItem.identifier), prefix)
+    }
 }

--- a/fearless/Common/Model/EraValidatorInfo.swift
+++ b/fearless/Common/Model/EraValidatorInfo.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+struct EraStakersInfo {
+    let era: UInt32
+    let validators: [EraValidatorInfo]
+}
+
+struct EraValidatorInfo {
+    let accountId: Data
+    let exposure: ValidatorExposure
+    let prefs: ValidatorPrefs
+}

--- a/fearless/Common/Network/JSONRPC/JSONRPCAliases.swift
+++ b/fearless/Common/Network/JSONRPC/JSONRPCAliases.swift
@@ -2,3 +2,4 @@ import Foundation
 
 typealias RuntimeVersionUpdate = JSONRPCSubscriptionUpdate<RuntimeVersion>
 typealias StorageSubscriptionUpdate = JSONRPCSubscriptionUpdate<StorageUpdate>
+typealias JSONRPCQueryOperation = JSONRPCOperation<[[String]], [StorageUpdate]>

--- a/fearless/Common/Network/JSONRPC/PagedKeysRequest.swift
+++ b/fearless/Common/Network/JSONRPC/PagedKeysRequest.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+struct PagedKeysRequest: Encodable {
+    let key: String
+    let count: UInt32
+    let offset: String?
+
+    init(key: String, count: UInt32 = 1000, offset: String? = nil) {
+        self.key = key
+        self.count = count
+        self.offset = offset
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(key)
+        try container.encode(count)
+
+        if let offset = offset {
+            try container.encode(offset)
+        }
+    }
+}

--- a/fearless/Common/Network/JSONRPC/RPCMethod.swift
+++ b/fearless/Common/Network/JSONRPC/RPCMethod.swift
@@ -4,6 +4,7 @@ enum RPCMethod {
     static let storageSubscibe = "state_subscribeStorage"
     static let chain = "system_chain"
     static let getStorage = "state_getStorage"
+    static let getStorageKeysPaged = "state_getKeysPaged"
     static let queryStorageAt = "state_queryStorageAt"
     static let getBlockHash = "chain_getBlockHash"
     static let submitExtrinsic = "author_submitExtrinsic"

--- a/fearless/Common/Network/JSONRPC/WebSocketEngine+Delegate.swift
+++ b/fearless/Common/Network/JSONRPC/WebSocketEngine+Delegate.swift
@@ -76,14 +76,14 @@ extension WebSocketEngine: WebSocketDelegate {
 
     private func handleBinaryEvent(data: Data) {
         if let decodedString = String(data: data, encoding: .utf8) {
-            logger.debug("Did receive data: \(decodedString)")
+            logger.debug("Did receive data: \(decodedString.prefix(1024))")
         }
 
         process(data: data)
     }
 
     private func handleTextEvent(string: String) {
-        logger.debug("Did receive text: \(string)")
+        logger.debug("Did receive text: \(string.prefix(1024))")
         if let data = string.data(using: .utf8) {
             process(data: data)
         } else {

--- a/fearless/Common/Network/WalletNetworkFacade+Storage.swift
+++ b/fearless/Common/Network/WalletNetworkFacade+Storage.swift
@@ -80,19 +80,15 @@ extension WalletNetworkFacade {
     }
 
     func queryStorageByKey<T: ScaleDecodable>(_ storageKey: Data) -> CompoundOperationWrapper<T?> {
-        do {
-            let identifier = try localStorageIdFactory.createIdentifier(for: storageKey)
-            return chainStorage.queryStorageByKey(identifier)
-        } catch {
-            return CompoundOperationWrapper.createWithError(error)
-        }
+        let identifier = localStorageIdFactory.createIdentifier(for: storageKey)
+        return chainStorage.queryStorageByKey(identifier)
     }
 
     func queryAccountInfoByKey(_ storageKey: Data,
                                dependingOn upgradeOperation: CompoundOperationWrapper<Bool?>) ->
     CompoundOperationWrapper<AccountInfo?> {
         do {
-            let identifier = try localStorageIdFactory.createIdentifier(for: storageKey)
+            let identifier = localStorageIdFactory.createIdentifier(for: storageKey)
 
             let fetchOperation = chainStorage
                 .fetchOperation(by: identifier,

--- a/fearless/Common/Network/WalletNetworkOperationFactory.swift
+++ b/fearless/Common/Network/WalletNetworkOperationFactory.swift
@@ -47,7 +47,7 @@ final class WalletNetworkOperationFactory {
     func createUpgradedInfoFetchOperation() -> CompoundOperationWrapper<Bool?> {
         do {
             let remoteKey = try StorageKeyFactory().updatedDualRefCount()
-            let localKey = try localStorageIdFactory.createIdentifier(for: remoteKey)
+            let localKey = localStorageIdFactory.createIdentifier(for: remoteKey)
 
             return chainStorage.queryStorageByKey(localKey)
 

--- a/fearless/Common/Operation/StorageDecodingOperation.swift
+++ b/fearless/Common/Operation/StorageDecodingOperation.swift
@@ -1,0 +1,97 @@
+import Foundation
+import FearlessUtils
+import RobinHood
+
+enum StorageDecodingOperationError: Error {
+    case missingRequiredParams
+    case invalidStoragePath
+}
+
+final class StorageDecodingOperation<T: Decodable>: BaseOperation<T> {
+    var data: Data?
+    var codingFactory: RuntimeCoderFactoryProtocol?
+
+    let path: StorageCodingPath
+
+    init(path: StorageCodingPath, data: Data? = nil) {
+        self.path = path
+        self.data = data
+
+        super.init()
+    }
+
+    override func main() {
+        super.main()
+
+        if isCancelled {
+            return
+        }
+
+        if result != nil {
+            return
+        }
+
+        do {
+            guard let data = data, let factory = codingFactory else {
+                throw StorageDecodingOperationError.missingRequiredParams
+            }
+
+            guard let entry = factory.metadata.getStorageMetadata(in: path.moduleName,
+                                                                  storageName: path.itemName) else {
+                throw StorageDecodingOperationError.invalidStoragePath
+            }
+
+            let decoder = try factory.createDecoder(from: data)
+            let item: T = try decoder.read(of: entry.type.typeName)
+            result = .success(item)
+        } catch {
+            result = .failure(error)
+        }
+    }
+}
+
+final class StorageDecodingListOperation<T: Decodable>: BaseOperation<[T]> {
+    var dataList: [Data]?
+    var codingFactory: RuntimeCoderFactoryProtocol?
+
+    let path: StorageCodingPath
+
+    init(path: StorageCodingPath, dataList: [Data]? = nil) {
+        self.path = path
+        self.dataList = dataList
+
+        super.init()
+    }
+
+    override func main() {
+        super.main()
+
+        if isCancelled {
+            return
+        }
+
+        if result != nil {
+            return
+        }
+
+        do {
+            guard let dataList = dataList, let factory = codingFactory else {
+                throw StorageDecodingOperationError.missingRequiredParams
+            }
+
+            guard let entry = factory.metadata.getStorageMetadata(in: path.moduleName,
+                                                                  storageName: path.itemName) else {
+                throw StorageDecodingOperationError.invalidStoragePath
+            }
+
+            let items: [T] = try dataList.map { data in
+                let decoder = try factory.createDecoder(from: data)
+                return try decoder.read(of: entry.type.typeName)
+            }
+
+            result = .success(items)
+        } catch {
+            result = .failure(error)
+        }
+    }
+}

--- a/fearless/Common/Operation/StorageKeyEncodingOperation.swift
+++ b/fearless/Common/Operation/StorageKeyEncodingOperation.swift
@@ -1,0 +1,158 @@
+import Foundation
+import FearlessUtils
+import RobinHood
+
+enum StorageKeyEncodingOperationError: Error {
+    case missingRequiredParams
+    case incompatibleStorageType
+    case invalidStoragePath
+}
+
+final class MapKeyEncodingOperation<T: Encodable>: BaseOperation<[Data]> {
+    var keyParams: [T]?
+    var codingFactory: RuntimeCoderFactoryProtocol?
+
+    let path: StorageCodingPath
+    let storageKeyFactory: StorageKeyFactoryProtocol
+
+    init(path: StorageCodingPath, storageKeyFactory: StorageKeyFactoryProtocol, keyParams: [T]? = nil) {
+        self.path = path
+        self.keyParams = keyParams
+        self.storageKeyFactory = storageKeyFactory
+
+        super.init()
+    }
+
+    override func main() {
+        super.main()
+
+        if isCancelled {
+            return
+        }
+
+        if result != nil {
+            return
+        }
+
+        do {
+            guard let factory = codingFactory, let keyParams = keyParams else {
+                throw StorageKeyEncodingOperationError.missingRequiredParams
+            }
+
+            guard let entry = factory.metadata.getStorageMetadata(in: path.moduleName,
+                                                                  storageName: path.itemName) else {
+                throw StorageKeyEncodingOperationError.invalidStoragePath
+            }
+
+            let keyType: String
+            let hasher: StorageHasher
+
+            switch entry.type {
+            case .map(let mapEntry):
+                keyType = mapEntry.key
+                hasher = mapEntry.hasher
+            case .doubleMap(let doubleMapEntry):
+                keyType = doubleMapEntry.key1
+                hasher = doubleMapEntry.hasher
+            case .plain:
+                throw StorageKeyEncodingOperationError.incompatibleStorageType
+            }
+
+            let keys: [Data] = try keyParams.map { keyParam in
+                let encoder = factory.createEncoder()
+                try encoder.append(keyParam, ofType: keyType)
+
+                let encodedParam = try encoder.encode()
+
+                return try storageKeyFactory.createStorageKey(moduleName: path.moduleName,
+                                                              storageName: path.itemName,
+                                                              key: encodedParam,
+                                                              hasher: hasher)
+            }
+
+            result = .success(keys)
+        } catch {
+            result = .failure(error)
+        }
+    }
+}
+
+final class DoubleMapKeyEncodingOperation<T1: Encodable, T2: Encodable>: BaseOperation<[Data]> {
+    var keyParams1: [T1]?
+    var keyParams2: [T2]?
+    var codingFactory: RuntimeCoderFactoryProtocol?
+
+    let path: StorageCodingPath
+    let storageKeyFactory: StorageKeyFactoryProtocol
+
+    init(path: StorageCodingPath,
+         storageKeyFactory: StorageKeyFactoryProtocol,
+         keyParams1: [T1]? = nil,
+         keyParams2: [T2]? = nil) {
+        self.path = path
+        self.keyParams1 = keyParams1
+        self.keyParams2 = keyParams2
+        self.storageKeyFactory = storageKeyFactory
+
+        super.init()
+    }
+
+    override func main() {
+        super.main()
+
+        if isCancelled {
+            return
+        }
+
+        if result != nil {
+            return
+        }
+
+        do {
+            guard let factory = codingFactory,
+                  let keyParams1 = keyParams1,
+                  let keyParams2 = keyParams2,
+                  keyParams1.count == keyParams2.count else {
+                throw StorageKeyEncodingOperationError.missingRequiredParams
+            }
+
+            guard let entry = factory.metadata.getStorageMetadata(in: path.moduleName,
+                                                                  storageName: path.itemName) else {
+                throw StorageKeyEncodingOperationError.invalidStoragePath
+            }
+
+            guard case .doubleMap(let doubleMapEntry) = entry.type else {
+                throw StorageKeyEncodingOperationError.incompatibleStorageType
+            }
+
+            let keys: [Data] = try zip(keyParams1, keyParams2).map { param in
+                let encodedParam1 = try encodeParam(param.0,
+                                                    factory: factory,
+                                                    type: doubleMapEntry.key1)
+
+                let encodedParam2 = try encodeParam(param.1,
+                                                    factory: factory,
+                                                    type: doubleMapEntry.key2)
+
+                return try storageKeyFactory.createStorageKey(moduleName: path.moduleName,
+                                                              storageName: path.itemName,
+                                                              key1: encodedParam1,
+                                                              hasher1: doubleMapEntry.hasher,
+                                                              key2: encodedParam2,
+                                                              hasher2: doubleMapEntry.key2Hasher)
+            }
+
+            result = .success(keys)
+        } catch {
+            result = .failure(error)
+        }
+    }
+
+    private func encodeParam<T: Encodable>(_ param: T,
+                                           factory: RuntimeCoderFactoryProtocol,
+                                           type: String) throws -> Data {
+        let encoder = factory.createEncoder()
+        try encoder.append(param, ofType: type)
+        return try encoder.encode()
+    }
+}

--- a/fearless/Common/Operation/StorageRequestFactory.swift
+++ b/fearless/Common/Operation/StorageRequestFactory.swift
@@ -1,0 +1,181 @@
+import Foundation
+import RobinHood
+import FearlessUtils
+
+struct StorageResponse<T: Decodable> {
+    let key: Data
+    let data: Data?
+    let value: T?
+}
+
+protocol StorageRequestFactoryProtocol {
+    func queryItems<K, T>(engine: JSONRPCEngine,
+                          keyParams: @escaping  () throws -> [K],
+                          factory: @escaping  () throws -> RuntimeCoderFactoryProtocol,
+                          storagePath: StorageCodingPath)
+    -> CompoundOperationWrapper<[StorageResponse<T>]> where K: Encodable, T: Decodable
+
+    func queryItems<K1, K2, T>(engine: JSONRPCEngine,
+                               keyParams1: @escaping  () throws -> [K1],
+                               keyParams2: @escaping  () throws -> [K2],
+                               factory: @escaping  () throws -> RuntimeCoderFactoryProtocol,
+                               storagePath: StorageCodingPath)
+    -> CompoundOperationWrapper<[StorageResponse<T>]> where K1: Encodable, K2: Encodable, T: Decodable
+
+    func queryItems<T>(engine: JSONRPCEngine,
+                       keys: @escaping () throws -> [Data],
+                       factory: @escaping  () throws -> RuntimeCoderFactoryProtocol,
+                       storagePath: StorageCodingPath)
+    -> CompoundOperationWrapper<[StorageResponse<T>]> where T: Decodable
+}
+
+final class StorageRequestFactory: StorageRequestFactoryProtocol {
+    let remoteFactory: StorageKeyFactoryProtocol
+
+    init(remoteFactory: StorageKeyFactoryProtocol) {
+        self.remoteFactory = remoteFactory
+    }
+
+    func queryItems<T>(engine: JSONRPCEngine,
+                       keys: @escaping () throws -> [Data],
+                       factory: @escaping  () throws -> RuntimeCoderFactoryProtocol,
+                       storagePath: StorageCodingPath)
+    -> CompoundOperationWrapper<[StorageResponse<T>]> where T: Decodable {
+        let queryOperation = JSONRPCQueryOperation(engine: engine,
+                                                   method: RPCMethod.queryStorageAt)
+        queryOperation.configurationBlock = {
+            do {
+                let keys = try keys().map { $0.toHex(includePrefix: true) }
+                queryOperation.parameters = [keys]
+            } catch {
+                queryOperation.result = .failure(error)
+            }
+        }
+
+        let decodingOperation = StorageDecodingListOperation<T>(path: storagePath)
+        decodingOperation.configurationBlock = {
+            do {
+                let result = try queryOperation.extractNoCancellableResultData()
+
+                decodingOperation.codingFactory = try factory()
+
+                decodingOperation.dataList = result
+                    .flatMap({ StorageUpdateData(update: $0).changes })
+                    .compactMap { $0.value }
+            } catch {
+                decodingOperation.result = .failure(error)
+            }
+        }
+
+        decodingOperation.addDependency(queryOperation)
+
+        let mapOperation = ClosureOperation<[StorageResponse<T>]> {
+            let result = try queryOperation.extractNoCancellableResultData()
+            let keysData = result
+                .flatMap({ StorageUpdateData(update: $0).changes })
+                .reduce(into: [Data: Data]()) { (result, change) in
+                    if let data = change.value {
+                        result[change.key] = data
+                    }
+                }
+
+            let allKeys = result
+                .flatMap({ StorageUpdateData(update: $0).changes })
+                .map { $0.key }
+
+            let allNonzeroKeys = result
+                .flatMap({ StorageUpdateData(update: $0).changes })
+                .compactMap { $0.value != nil ? $0.key : nil }
+
+            let items = try decodingOperation.extractNoCancellableResultData()
+
+            let keyValue = zip(allNonzeroKeys, items).reduce(into: [Data: T]()) { (result, item) in
+                result[item.0] = item.1
+            }
+
+            return allKeys.map { key in
+                StorageResponse(key: key,
+                                data: keysData[key],
+                                value: keyValue[key])
+            }
+        }
+
+        mapOperation.addDependency(decodingOperation)
+
+        let dependencies = [queryOperation, decodingOperation]
+
+        return CompoundOperationWrapper(targetOperation: mapOperation,
+                                        dependencies: dependencies)
+    }
+
+    func queryItems<K, T>(engine: JSONRPCEngine,
+                          keyParams: @escaping  () throws -> [K],
+                          factory: @escaping  () throws -> RuntimeCoderFactoryProtocol,
+                          storagePath: StorageCodingPath)
+    -> CompoundOperationWrapper<[StorageResponse<T>]> where K: Encodable, T: Decodable {
+
+        let currentRemoteFactory = remoteFactory
+
+        let keysOperation = MapKeyEncodingOperation<K>(path: storagePath,
+                                                       storageKeyFactory: currentRemoteFactory)
+
+        keysOperation.configurationBlock = {
+            do {
+                keysOperation.keyParams = try keyParams()
+                keysOperation.codingFactory = try factory()
+            } catch {
+                keysOperation.result = .failure(error)
+            }
+        }
+
+        let keys: () throws -> [Data] = {
+            try keysOperation.extractNoCancellableResultData()
+        }
+
+        let queryWrapper: CompoundOperationWrapper<[StorageResponse<T>]> =
+            queryItems(engine: engine, keys: keys, factory: factory, storagePath: storagePath)
+
+        queryWrapper.allOperations.forEach { $0.addDependency(keysOperation) }
+
+        let dependencies = [keysOperation] + queryWrapper.dependencies
+
+        return CompoundOperationWrapper(targetOperation: queryWrapper.targetOperation,
+                                        dependencies: dependencies)
+    }
+
+    func queryItems<K1, K2, T>(engine: JSONRPCEngine,
+                               keyParams1: @escaping  () throws -> [K1],
+                               keyParams2: @escaping  () throws -> [K2],
+                               factory: @escaping  () throws -> RuntimeCoderFactoryProtocol,
+                               storagePath: StorageCodingPath)
+    -> CompoundOperationWrapper<[StorageResponse<T>]> where K1: Encodable, K2: Encodable, T: Decodable {
+        let currentRemoteFactory = remoteFactory
+
+        let keysOperation = DoubleMapKeyEncodingOperation<K1, K2>(path: storagePath,
+                                                                  storageKeyFactory: currentRemoteFactory)
+
+        keysOperation.configurationBlock = {
+            do {
+                keysOperation.keyParams1 = try keyParams1()
+                keysOperation.keyParams2 = try keyParams2()
+                keysOperation.codingFactory = try factory()
+            } catch {
+                keysOperation.result = .failure(error)
+            }
+        }
+
+        let keys: () throws -> [Data] = {
+            try keysOperation.extractNoCancellableResultData()
+        }
+
+        let queryWrapper: CompoundOperationWrapper<[StorageResponse<T>]> =
+            queryItems(engine: engine, keys: keys, factory: factory, storagePath: storagePath)
+
+        queryWrapper.allOperations.forEach { $0.addDependency(keysOperation) }
+
+        let dependencies = [keysOperation] + queryWrapper.dependencies
+
+        return CompoundOperationWrapper(targetOperation: queryWrapper.targetOperation,
+                                        dependencies: dependencies)
+    }
+}

--- a/fearless/Common/Scale/Types/ActiveEraInfo.swift
+++ b/fearless/Common/Scale/Types/ActiveEraInfo.swift
@@ -1,0 +1,6 @@
+import Foundation
+import FearlessUtils
+
+struct ActiveEraInfo: Codable {
+    @StringCodable var index: UInt32
+}

--- a/fearless/Common/Scale/Types/RuntimeKnown.swift
+++ b/fearless/Common/Scale/Types/RuntimeKnown.swift
@@ -1,6 +1,0 @@
-import Foundation
-
-struct SystemModule {
-    static let name = "System"
-    static let account = "Account"
-}

--- a/fearless/Common/Scale/Types/StorageCodingPath.swift
+++ b/fearless/Common/Scale/Types/StorageCodingPath.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+struct StorageCodingPath {
+    let moduleName: String
+    let itemName: String
+}
+
+extension StorageCodingPath {
+    static var account: StorageCodingPath {
+        StorageCodingPath(moduleName: "System", itemName: "Account")
+    }
+
+    static var activeEra: StorageCodingPath {
+        StorageCodingPath(moduleName: "Staking", itemName: "ActiveEra")
+    }
+
+    static var erasStakers: StorageCodingPath {
+        StorageCodingPath(moduleName: "Staking", itemName: "ErasStakers")
+    }
+
+    static var validatorPrefs: StorageCodingPath {
+        StorageCodingPath(moduleName: "Staking", itemName: "Validators")
+    }
+}

--- a/fearless/Common/Scale/Types/StorageCodingPath.swift
+++ b/fearless/Common/Scale/Types/StorageCodingPath.swift
@@ -18,6 +18,10 @@ extension StorageCodingPath {
         StorageCodingPath(moduleName: "Staking", itemName: "ErasStakers")
     }
 
+    static var erasPrefs: StorageCodingPath {
+        StorageCodingPath(moduleName: "Staking", itemName: "ErasValidatorPrefs")
+    }
+
     static var validatorPrefs: StorageCodingPath {
         StorageCodingPath(moduleName: "Staking", itemName: "Validators")
     }

--- a/fearless/Common/Scale/Types/ValidatorExposure.swift
+++ b/fearless/Common/Scale/Types/ValidatorExposure.swift
@@ -1,0 +1,14 @@
+import Foundation
+import FearlessUtils
+import BigInt
+
+struct ValidatorExposure: Codable {
+    @StringCodable var total: BigUInt
+    @StringCodable var own: BigUInt
+    let others: [IndividualExposure]
+}
+
+struct IndividualExposure: Codable {
+    let who: Data
+    @StringCodable var value: BigUInt
+}

--- a/fearless/Common/Scale/Types/ValidatorPrefs.swift
+++ b/fearless/Common/Scale/Types/ValidatorPrefs.swift
@@ -1,0 +1,7 @@
+import Foundation
+import FearlessUtils
+import BigInt
+
+struct ValidatorPrefs: Codable {
+    @StringCodable var commission: BigUInt
+}

--- a/fearless/Common/Services/EraValidatorsService/EraValidatorFactory.swift
+++ b/fearless/Common/Services/EraValidatorsService/EraValidatorFactory.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 final class EraValidatorFactory {
-    static func createService(from chain: Chain) -> EraValidatorServiceProtocol & EraValidatorProviderProtocol {
+    static func createService(runtime: RuntimeCodingServiceProtocol) -> EraValidatorServiceProtocol {
         let storageFacade = SubstrateDataStorageFacade.shared
         let operationManager = OperationManagerFacade.sharedManager
         let logger = Logger.shared
@@ -10,11 +10,9 @@ final class EraValidatorFactory {
                                                            operationManager: operationManager,
                                                            logger: logger)
 
-        return EraValidatorService(chain: chain,
-                                   storageFacade: SubstrateDataStorageFacade.shared,
-                                   runtimeCodingService: RuntimeRegistryFacade.sharedService,
+        return EraValidatorService(storageFacade: SubstrateDataStorageFacade.shared,
+                                   runtimeCodingService: runtime,
                                    providerFactory: providerFactory,
-                                   webSocketService: WebSocketService.shared,
                                    operationManager: operationManager,
                                    logger: logger)
     }

--- a/fearless/Common/Services/EraValidatorsService/EraValidatorFactory.swift
+++ b/fearless/Common/Services/EraValidatorsService/EraValidatorFactory.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+final class EraValidatorFactory {
+    static func createService(from chain: Chain) -> EraValidatorServiceProtocol & EraValidatorProviderProtocol {
+        let storageFacade = SubstrateDataStorageFacade.shared
+        let operationManager = OperationManagerFacade.sharedManager
+        let logger = Logger.shared
+
+        let providerFactory = SubstrateDataProviderFactory(facade: storageFacade,
+                                                           operationManager: operationManager,
+                                                           logger: logger)
+
+        return EraValidatorService(chain: chain,
+                                   storageFacade: SubstrateDataStorageFacade.shared,
+                                   runtimeCodingService: RuntimeRegistryFacade.sharedService,
+                                   providerFactory: providerFactory,
+                                   webSocketService: WebSocketService.shared,
+                                   operationManager: operationManager,
+                                   logger: logger)
+    }
+}

--- a/fearless/Common/Services/EraValidatorsService/EraValidatorService.swift
+++ b/fearless/Common/Services/EraValidatorsService/EraValidatorService.swift
@@ -1,0 +1,372 @@
+import Foundation
+import RobinHood
+import FearlessUtils
+
+private typealias IdentifiableExposure = (Data, ValidatorExposure)
+
+enum EraValidatorServiceError: Error {
+    case unsuppotedStoragePath(_ path: StorageCodingPath)
+}
+
+final class EraValidatorService {
+    static let queueLabelPrefix = "jp.co.fearless.recvalidators"
+
+    private let syncQueue = DispatchQueue(label: "\(queueLabelPrefix).\(UUID().uuidString)")
+
+    private var activeEra: UInt32?
+    private var snapshot: EraStakersInfo?
+    let storageFacade: StorageFacadeProtocol
+    let runtimeCodingService: RuntimeCodingServiceProtocol
+    let eraDataProvider: StreamableProvider<ChainStorageItem>
+    let engine: JSONRPCEngine
+    let operationManager: OperationManagerProtocol
+    let storageKeyFactory: StorageKeyFactoryProtocol
+    let localKeyFactory: ChainStorageIdFactoryProtocol
+    let logger: LoggerProtocol
+
+    init(storageFacade: StorageFacadeProtocol,
+         runtimeCodingService: RuntimeCodingServiceProtocol,
+         eraDataProvider: StreamableProvider<ChainStorageItem>,
+         engine: JSONRPCEngine,
+         operationManager: OperationManagerProtocol,
+         storageKeyFactory: StorageKeyFactoryProtocol,
+         localKeyFactory: ChainStorageIdFactoryProtocol,
+         logger: LoggerProtocol) {
+        self.storageFacade = storageFacade
+        self.runtimeCodingService = runtimeCodingService
+        self.eraDataProvider = eraDataProvider
+        self.engine = engine
+        self.operationManager = operationManager
+        self.storageKeyFactory = storageKeyFactory
+        self.localKeyFactory = localKeyFactory
+        self.logger = logger
+    }
+
+    private func updateValidators(activeEra: UInt32,
+                                  exposures: [IdentifiableExposure],
+                                  prefs: [StorageResponse<ValidatorPrefs>]) {
+        guard activeEra == self.activeEra else {
+            Logger.shared.warning("Validators fetched but era changed. Cancelled.")
+            return
+        }
+
+        let keyedPrefs = prefs.reduce(into: [Data: ValidatorPrefs]()) { (result, item) in
+            result[item.key] = item.value
+        }
+
+        let validators: [EraValidatorInfo] = exposures.compactMap { item in
+            guard let pref = keyedPrefs[item.0] else {
+                return nil
+            }
+
+            return EraValidatorInfo(accountId: item.0,
+                                    exposure: item.1,
+                                    prefs: pref)
+        }
+
+        snapshot = EraStakersInfo(era: activeEra,
+                                  validators: validators)
+    }
+
+    private func updatePrefsAndSave(activeEra: UInt32,
+                                    exposures: [IdentifiableExposure],
+                                    codingFactory: RuntimeCoderFactoryProtocol) {
+        guard activeEra == self.activeEra else {
+            Logger.shared.warning("Validators fetched but era changed. Cancelled.")
+            return
+        }
+
+        guard !exposures.isEmpty else {
+            logger.warning("Tried to fetch prefs but era missing")
+            return
+        }
+
+        let params1: () throws -> [UInt32] = {
+            Array(repeating: activeEra, count: exposures.count)
+        }
+
+        let params2: () throws -> [Data] = {
+            exposures.map { $0.0 }
+        }
+
+        let requestFactory = StorageRequestFactory(remoteFactory: storageKeyFactory)
+
+        let queryWrapper: CompoundOperationWrapper<[StorageResponse<ValidatorPrefs>]> =
+            requestFactory.queryItems(engine: engine,
+                                      keyParams1: params1,
+                                      keyParams2: params2,
+                                      factory: { codingFactory },
+                                      storagePath: .validatorPrefs)
+
+        queryWrapper.targetOperation.completionBlock = { [weak self] in
+            self?.syncQueue.async {
+                do {
+                    let prefs = try queryWrapper.targetOperation.extractNoCancellableResultData()
+                    self?.updateValidators(activeEra: activeEra,
+                                           exposures: exposures,
+                                           prefs: prefs)
+                } catch {
+                    self?.logger.error("Prefs fetching failed: \(error)")
+                }
+            }
+        }
+
+        operationManager.enqueue(operations: queryWrapper.allOperations, in: .transient)
+    }
+
+    private func updateFromRemote(activeEra: UInt32,
+                                  prefixKey: Data,
+                                  repository: AnyDataProviderRepository<ChainStorageItem>,
+                                  codingFactory: RuntimeCoderFactoryProtocol) {
+        guard activeEra == self.activeEra else {
+            Logger.shared.warning("Validators fetched but era changed. Cancelled.")
+            return
+        }
+
+        let currentLocalFactory = localKeyFactory
+
+        let request = PagedKeysRequest(key: prefixKey.toHex(includePrefix: true))
+        let remoteValidatorIdsOperation =
+            JSONRPCOperation<PagedKeysRequest, [String]>(engine: engine,
+                                                         method: RPCMethod.getStorageKeysPaged,
+                                                         parameters: request)
+
+        let keys: () throws -> [Data] = {
+            let hexKeys = try remoteValidatorIdsOperation.extractNoCancellableResultData()
+            return try hexKeys.map { try Data(hexString: $0) }
+        }
+
+        let requestFactory = StorageRequestFactory(remoteFactory: storageKeyFactory)
+
+        let queryWrapper: CompoundOperationWrapper<[StorageResponse<ValidatorExposure>]> =
+            requestFactory.queryItems(engine: engine,
+                                      keys: keys,
+                                      factory: { codingFactory },
+                                      storagePath: .erasStakers)
+
+        let saveOperation = repository.saveOperation({
+            let result = try queryWrapper.targetOperation.extractNoCancellableResultData()
+            return result.compactMap { item in
+                    if let data = item.data {
+                        let localId = currentLocalFactory.createIdentifier(for: item.key)
+                        return ChainStorageItem(identifier: localId, data: data)
+                    } else {
+                        return nil
+                    }
+                }
+        }, { [] })
+
+        saveOperation.addDependency(queryWrapper.targetOperation)
+
+        let operations = queryWrapper.allOperations + [saveOperation]
+
+        saveOperation.completionBlock = { [weak self] in
+            self?.syncQueue.async {
+                do {
+                    let result = try queryWrapper.targetOperation.extractNoCancellableResultData()
+                    let exposures: [IdentifiableExposure] = result.compactMap { item in
+                        guard let value = item.value else {
+                            return nil
+                        }
+
+                        let accountId = item.key.suffix(Int(ExtrinsicConstants.accountIdLength))
+                        return (accountId, value)
+                    }
+
+                    self?.updatePrefsAndSave(activeEra: activeEra,
+                                             exposures: exposures,
+                                             codingFactory: codingFactory)
+                } catch {
+                    self?.logger.error("Remote exposure failed: \(error)")
+                }
+            }
+        }
+
+        operationManager.enqueue(operations: operations, in: .transient)
+    }
+
+    private func createLocalValidatorsWrapper(repository: AnyDataProviderRepository<ChainStorageItem>,
+                                              codingFactory: RuntimeCoderFactoryProtocol)
+    -> CompoundOperationWrapper<[IdentifiableExposure]> {
+        let fetchOperation = repository.fetchAllOperation(with: RepositoryFetchOptions())
+
+        let decodingOperation = StorageDecodingListOperation<ValidatorExposure>(path: .erasStakers)
+        decodingOperation.codingFactory = codingFactory
+
+        decodingOperation.configurationBlock = {
+            do {
+                guard let validators = try fetchOperation.extractResultData() else {
+                    decodingOperation.cancel()
+                    return
+                }
+
+                decodingOperation.dataList = validators.map { $0.data }
+            } catch {
+                decodingOperation.result = .failure(error)
+            }
+        }
+
+        decodingOperation.addDependency(fetchOperation)
+
+        let mapOperation: BaseOperation<[IdentifiableExposure]> = ClosureOperation {
+            let identifiers = try fetchOperation.extractNoCancellableResultData().map { item in
+                try Data(hexString: item.identifier)
+                    .suffix(Int(ExtrinsicConstants.accountIdLength))
+            }
+            let validators = try decodingOperation.extractNoCancellableResultData()
+
+            return Array(zip(identifiers, validators))
+        }
+
+        mapOperation.addDependency(decodingOperation)
+
+        return CompoundOperationWrapper(targetOperation: mapOperation,
+                                        dependencies: [fetchOperation, decodingOperation])
+    }
+
+    private func updateIfNeeded(activeEra: UInt32,
+                                prefixKey: Data,
+                                codingFactory: RuntimeCoderFactoryProtocol) {
+        guard activeEra == self.activeEra else {
+            Logger.shared.warning("Validators fetched but era changed. Cancelled.")
+            return
+        }
+
+        let localPrefixKey = localKeyFactory.createIdentifier(for: prefixKey)
+        let filter = NSPredicate.filterByIdPrefix(localPrefixKey)
+
+        let repository: CoreDataRepository<ChainStorageItem, CDChainStorageItem> =
+            storageFacade.createRepository(filter: filter)
+        let anyRepository = AnyDataProviderRepository(repository)
+
+        let localValidatorsWrapper =
+            createLocalValidatorsWrapper(repository: anyRepository,
+                                         codingFactory: codingFactory)
+
+        localValidatorsWrapper.targetOperation.completionBlock = { [weak self] in
+            self?.syncQueue.async {
+                do {
+                    let validators = try localValidatorsWrapper.targetOperation
+                        .extractNoCancellableResultData()
+
+                    if validators.isEmpty {
+                        self?.updateFromRemote(activeEra: activeEra,
+                                               prefixKey: prefixKey,
+                                               repository: AnyDataProviderRepository(repository),
+                                               codingFactory: codingFactory)
+                    } else {
+                        self?.updatePrefsAndSave(activeEra: activeEra,
+                                                 exposures: validators,
+                                                 codingFactory: codingFactory)
+                    }
+                } catch {
+                    self?.logger.error("Local fetch failed: \(error)")
+                }
+            }
+        }
+
+        operationManager.enqueue(operations: localValidatorsWrapper.allOperations,
+                                 in: .transient)
+    }
+
+    private func preparePrefixKeyAndUpdateIfNeeded() {
+        guard let activeEra = activeEra else {
+            return
+        }
+
+        let codingFactoryOperation = runtimeCodingService.fetchCoderFactoryOperation()
+        let erasStakersKeyOperation = MapKeyEncodingOperation(path: .erasStakers,
+                                                              storageKeyFactory: storageKeyFactory,
+                                                              keyParams: [activeEra])
+
+        erasStakersKeyOperation.configurationBlock = {
+            do {
+                erasStakersKeyOperation.codingFactory =
+                    try codingFactoryOperation.extractNoCancellableResultData()
+            } catch {
+                erasStakersKeyOperation.result = .failure(error)
+            }
+        }
+
+        erasStakersKeyOperation.addDependency(codingFactoryOperation)
+
+        erasStakersKeyOperation.completionBlock = { [weak self] in
+            self?.syncQueue.async {
+                switch erasStakersKeyOperation.result {
+                case .success(let prefixKeys):
+                    if let factory = erasStakersKeyOperation.codingFactory, let prefixKey = prefixKeys.first {
+                        self?.updateIfNeeded(activeEra: activeEra, prefixKey: prefixKey, codingFactory: factory)
+                    } else {
+                        self?.logger.warning("Can't find coding factory or eras key")
+                    }
+                case .failure(let error):
+                    self?.logger.error("Prefix key encoding error: \(error)")
+                case .none:
+                    self?.logger.warning("Did cancel prefix key encoding")
+                }
+            }
+        }
+    }
+
+    private func handleEraDecodingResult(_ result: Result<UInt32, Error>?) {
+        switch result {
+        case .success(let era):
+            self.activeEra = era
+            preparePrefixKeyAndUpdateIfNeeded()
+        case .failure(let error):
+            logger.error("Did receive era decoding error: \(error)")
+        case .none:
+            logger.warning("Error decoding operation canceled")
+        }
+    }
+
+    private func didUpdateActiveEraItem(_ eraItem: ChainStorageItem?) {
+        guard let eraItem = eraItem else {
+            return
+        }
+
+        let codingFactoryOperation = runtimeCodingService.fetchCoderFactoryOperation()
+        let decodingOperation = StorageDecodingOperation<UInt32>(path: .activeEra,
+                                                                 data: eraItem.data)
+
+        decodingOperation.addDependency(codingFactoryOperation)
+
+        decodingOperation.completionBlock = { [weak self] in
+            self?.syncQueue.async {
+                self?.handleEraDecodingResult(decodingOperation.result)
+            }
+        }
+
+        operationManager.enqueue(operations: [codingFactoryOperation, decodingOperation],
+                                 in: .transient)
+    }
+
+    private func subscribe() {
+        let updateClosure: ([DataProviderChange<ChainStorageItem>]) -> Void = { [weak self] changes in
+            let finalValue: ChainStorageItem? = changes.reduce(nil) { (_, item) in
+                switch item {
+                case .insert(let newItem), .update(let newItem):
+                    return newItem
+                case .delete:
+                    return nil
+                }
+            }
+
+            self?.didUpdateActiveEraItem(finalValue)
+        }
+
+        let failureClosure: (Error) -> Void = { [weak self] (error) in
+            self?.logger.error("Did receive error: \(error)")
+        }
+
+        eraDataProvider.addObserver(self,
+                                    deliverOn: syncQueue,
+                                    executing: updateClosure,
+                                    failing: failureClosure,
+                                    options: StreamableProviderObserverOptions())
+    }
+
+    private func unsubscribe() {
+        eraDataProvider.removeObserver(self)
+    }
+}

--- a/fearless/Common/Services/EraValidatorsService/EraValidatorServiceProtocol.swift
+++ b/fearless/Common/Services/EraValidatorsService/EraValidatorServiceProtocol.swift
@@ -2,15 +2,12 @@ import Foundation
 import RobinHood
 
 protocol EraValidatorServiceProtocol: ApplicationServiceProtocol {
-    func update(to chain: Chain)
-}
-
-protocol EraValidatorProviderProtocol {
+    func update(to chain: Chain, engine: JSONRPCEngine)
     func fetchInfoOperation(with timeout: TimeInterval) -> BaseOperation<EraStakersInfo>
 }
 
-extension EraValidatorProviderProtocol {
-    func fetchInfoOperation(with timeout: TimeInterval = 20.0) -> BaseOperation<EraStakersInfo> {
-        fetchInfoOperation(with: timeout)
+extension EraValidatorServiceProtocol {
+    func fetchInfoOperation() -> BaseOperation<EraStakersInfo> {
+        fetchInfoOperation(with: 20.0)
     }
 }

--- a/fearless/Common/Services/EraValidatorsService/EraValidatorServiceProtocol.swift
+++ b/fearless/Common/Services/EraValidatorsService/EraValidatorServiceProtocol.swift
@@ -1,6 +1,16 @@
 import Foundation
 import RobinHood
 
-protocol EraValidatorServiceProtocol {
-    func fetchOperation(with timeout: TimeInterval) -> BaseOperation<[DyAccountInfo]>
+protocol EraValidatorServiceProtocol: ApplicationServiceProtocol {
+    func update(to chain: Chain)
+}
+
+protocol EraValidatorProviderProtocol {
+    func fetchInfoOperation(with timeout: TimeInterval) -> BaseOperation<EraStakersInfo>
+}
+
+extension EraValidatorProviderProtocol {
+    func fetchInfoOperation(with timeout: TimeInterval = 20.0) -> BaseOperation<EraStakersInfo> {
+        fetchInfoOperation(with: timeout)
+    }
 }

--- a/fearless/Common/Services/EraValidatorsService/EraValidatorServiceProtocol.swift
+++ b/fearless/Common/Services/EraValidatorsService/EraValidatorServiceProtocol.swift
@@ -1,0 +1,6 @@
+import Foundation
+import RobinHood
+
+protocol EraValidatorServiceProtocol {
+    func fetchOperation(with timeout: TimeInterval) -> BaseOperation<[DyAccountInfo]>
+}

--- a/fearless/Common/Services/GitHubPhishingService/GitHubPhishingServiceFactory.swift
+++ b/fearless/Common/Services/GitHubPhishingService/GitHubPhishingServiceFactory.swift
@@ -1,13 +1,8 @@
 import Foundation
 import RobinHood
 
-protocol GitHubPhishingServiceFactoryProtocol {
-    func createGitHubService() -> ApplicationServiceProtocol
-}
-
-class GitHubPhishingServiceFactory: GitHubPhishingServiceFactoryProtocol {
-
-    func createGitHubService() -> ApplicationServiceProtocol {
+class GitHubPhishingServiceFactory {
+    static func createService() -> ApplicationServiceProtocol {
         let logger = Logger.shared
         let storage: CoreDataRepository<PhishingItem, CDPhishingItem> =
             SubstrateDataStorageFacade.shared.createRepository()

--- a/fearless/Common/Services/ServiceCoordinator.swift
+++ b/fearless/Common/Services/ServiceCoordinator.swift
@@ -1,0 +1,99 @@
+import Foundation
+import SoraKeystore
+import SoraFoundation
+
+protocol ServiceCoordinatorProtocol: ApplicationServiceProtocol {
+    func updateOnAccountChange()
+    func updateOnNetworkChange()
+}
+
+final class ServiceCoordinator {
+    let webSocketService: WebSocketServiceProtocol
+    let runtimeService: RuntimeRegistryServiceProtocol
+    let validatorService: EraValidatorServiceProtocol
+    let gitHubPhishingAPIService: ApplicationServiceProtocol
+    let settings: SettingsManagerProtocol
+
+    init(webSocketService: WebSocketServiceProtocol,
+         runtimeService: RuntimeRegistryServiceProtocol,
+         validatorService: EraValidatorServiceProtocol,
+         gitHubPhishingAPIService: ApplicationServiceProtocol,
+         settings: SettingsManagerProtocol) {
+        self.webSocketService = webSocketService
+        self.runtimeService = runtimeService
+        self.validatorService = validatorService
+        self.gitHubPhishingAPIService = gitHubPhishingAPIService
+        self.settings = settings
+    }
+
+    private func updateWebSocketSettings() {
+        let connectionItem = settings.selectedConnection
+        let account = settings.selectedAccount
+
+        let settings = WebSocketServiceSettings(url: connectionItem.url,
+                                                addressType: connectionItem.type,
+                                                address: account?.address)
+        webSocketService.update(settings: settings)
+    }
+
+    private func updateRuntimeService() {
+        let connectionItem = settings.selectedConnection
+        runtimeService.update(to: connectionItem.type.chain)
+    }
+
+    private func updateValidatorService() {
+        if let engine = webSocketService.connection {
+            let chain = settings.selectedConnection.type.chain
+            validatorService.update(to: chain, engine: engine)
+        }
+    }
+}
+
+extension ServiceCoordinator: ServiceCoordinatorProtocol {
+    func updateOnAccountChange() {
+        updateWebSocketSettings()
+        updateRuntimeService()
+        updateValidatorService()
+    }
+
+    func updateOnNetworkChange() {
+        updateWebSocketSettings()
+        updateRuntimeService()
+        updateValidatorService()
+    }
+
+    func setup() {
+        webSocketService.setup()
+        runtimeService.setup()
+
+        if let engine = webSocketService.connection {
+            let chain = settings.selectedConnection.type.chain
+            validatorService.update(to: chain, engine: engine)
+            validatorService.setup()
+        }
+
+        gitHubPhishingAPIService.setup()
+    }
+
+    func throttle() {
+        webSocketService.throttle()
+        runtimeService.throttle()
+        validatorService.throttle()
+        gitHubPhishingAPIService.throttle()
+    }
+}
+
+extension ServiceCoordinator {
+    static func createDefault() -> ServiceCoordinatorProtocol {
+        let webSocketService = WebSocketServiceFactory.createService()
+        let runtimeService = RuntimeRegistryFacade.sharedService
+        let gitHubPhishingAPIService = GitHubPhishingServiceFactory.createService()
+        let validatorService = EraValidatorFactory.createService(runtime: runtimeService)
+
+        return ServiceCoordinator(webSocketService: webSocketService,
+                                  runtimeService: runtimeService,
+                                  validatorService: validatorService,
+                                  gitHubPhishingAPIService: gitHubPhishingAPIService,
+                                  settings: SettingsManager.shared)
+    }
+}

--- a/fearless/Common/Services/WebSocketService/StorageSubscription/StakingInfoSubscription.swift
+++ b/fearless/Common/Services/WebSocketService/StorageSubscription/StakingInfoSubscription.swift
@@ -89,7 +89,7 @@ final class StakingInfoSubscription: WebSocketSubscribing {
             // save by stash id to avoid intermediate call to controller
             let storageKey = try StorageKeyFactory().stakingInfoForControllerId(stashId)
 
-            let identifier = try localStorageIdFactory.createIdentifier(for: storageKey)
+            let identifier = localStorageIdFactory.createIdentifier(for: storageKey)
 
             let fetchOperation = storage.fetchOperation(by: identifier,
                                                         options: RepositoryFetchOptions())

--- a/fearless/Common/Services/WebSocketService/StorageSubscription/TransferSubscription.swift
+++ b/fearless/Common/Services/WebSocketService/StorageSubscription/TransferSubscription.swift
@@ -144,7 +144,7 @@ final class TransferSubscription {
     private func createUpgradedOperation() -> CompoundOperationWrapper<Bool?> {
         do {
             let remoteKey = try StorageKeyFactory().updatedDualRefCount()
-            let localKey = try localIdFactory.createIdentifier(for: remoteKey)
+            let localKey = localIdFactory.createIdentifier(for: remoteKey)
 
             return chainStorage.queryStorageByKey(localKey)
         } catch {

--- a/fearless/Common/Services/WebSocketService/WebSocketServiceFactory.swift
+++ b/fearless/Common/Services/WebSocketService/WebSocketServiceFactory.swift
@@ -1,0 +1,26 @@
+import Foundation
+import SoraFoundation
+
+final class WebSocketServiceFactory {
+    static func createService() -> WebSocketServiceProtocol {
+        let localizationManager = LocalizationManager.shared
+        let webSocketService = WebSocketService.shared
+        webSocketService.networkStatusPresenter =
+            createNetworkStatusPresenter(localizationManager: localizationManager)
+
+        return webSocketService
+    }
+
+    static func createNetworkStatusPresenter(localizationManager: LocalizationManagerProtocol)
+        -> NetworkAvailabilityLayerInteractorOutputProtocol? {
+        guard let window = UIApplication.shared.keyWindow as? ApplicationStatusPresentable else {
+            return nil
+        }
+
+        let prenseter = NetworkAvailabilityLayerPresenter()
+        prenseter.localizationManager = localizationManager
+        prenseter.view = window
+
+        return prenseter
+    }
+}

--- a/fearless/Common/Services/WebSocketService/WebSocketSubscriptionFactory.swift
+++ b/fearless/Common/Services/WebSocketService/WebSocketSubscriptionFactory.swift
@@ -94,7 +94,7 @@ final class WebSocketSubscriptionFactory: WebSocketSubscriptionFactoryProtocol {
     throws -> AccountInfoSubscription {
         let accountStorageKey = try storageKeyFactory.accountInfoKeyForId(accountId)
 
-        let localStorageKey = try localStorageIdFactory.createIdentifier(for: accountStorageKey)
+        let localStorageKey = localStorageIdFactory.createIdentifier(for: accountStorageKey)
 
         let storage: CoreDataRepository<ChainStorageItem, CDChainStorageItem> =
             SubstrateDataStorageFacade.shared.createRepository()
@@ -112,7 +112,7 @@ final class WebSocketSubscriptionFactory: WebSocketSubscriptionFactoryProtocol {
                                              localStorageIdFactory: ChainStorageIdFactoryProtocol)
     throws -> ActiveEraSubscription {
         let remoteStorageKey = try storageKeyFactory.activeEra()
-        let localStorageKey = try localStorageIdFactory.createIdentifier(for: remoteStorageKey)
+        let localStorageKey = localStorageIdFactory.createIdentifier(for: remoteStorageKey)
 
         let storage: CoreDataRepository<ChainStorageItem, CDChainStorageItem> =
             SubstrateDataStorageFacade.shared.createRepository()
@@ -129,7 +129,7 @@ final class WebSocketSubscriptionFactory: WebSocketSubscriptionFactoryProtocol {
                                               localStorageIdFactory: ChainStorageIdFactoryProtocol)
     throws -> CurrentEraSubscription {
         let remoteStorageKey = try storageKeyFactory.currentEra()
-        let localStorageKey = try localStorageIdFactory.createIdentifier(for: remoteStorageKey)
+        let localStorageKey = localStorageIdFactory.createIdentifier(for: remoteStorageKey)
 
         let storage: CoreDataRepository<ChainStorageItem, CDChainStorageItem> =
             SubstrateDataStorageFacade.shared.createRepository()
@@ -146,7 +146,7 @@ final class WebSocketSubscriptionFactory: WebSocketSubscriptionFactoryProtocol {
                                                  localStorageIdFactory: ChainStorageIdFactoryProtocol)
     throws -> TotalIssuanceSubscription {
         let remoteStorageKey = try storageKeyFactory.totalIssuance()
-        let localStorageKey = try localStorageIdFactory.createIdentifier(for: remoteStorageKey)
+        let localStorageKey = localStorageIdFactory.createIdentifier(for: remoteStorageKey)
 
         let storage: CoreDataRepository<ChainStorageItem, CDChainStorageItem> =
             SubstrateDataStorageFacade.shared.createRepository()
@@ -191,7 +191,7 @@ final class WebSocketSubscriptionFactory: WebSocketSubscriptionFactoryProtocol {
                                        localStorageIdFactory: ChainStorageIdFactoryProtocol)
     throws -> UpgradeV28Subscription {
         let remoteStorageKey = try storageKeyFactory.updatedDualRefCount()
-        let localStorageKey = try localStorageIdFactory.createIdentifier(for: remoteStorageKey)
+        let localStorageKey = localStorageIdFactory.createIdentifier(for: remoteStorageKey)
 
         let storage: CoreDataRepository<ChainStorageItem, CDChainStorageItem> =
             SubstrateDataStorageFacade.shared.createRepository()

--- a/fearless/Common/Storage/ChainStorageIdFactory.swift
+++ b/fearless/Common/Storage/ChainStorageIdFactory.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 protocol ChainStorageIdFactoryProtocol {
-    func createIdentifier(for key: Data) throws -> String
+    func createIdentifier(for key: Data) -> String
 }
 
 final class ChainStorageIdFactory: ChainStorageIdFactoryProtocol {
@@ -11,7 +11,7 @@ final class ChainStorageIdFactory: ChainStorageIdFactoryProtocol {
         genesisData = try Data(hexString: chain.genesisHash)
     }
 
-    func createIdentifier(for key: Data)  throws -> String {
-        try (key + genesisData).blake2b32().toHex(includePrefix: true)
+    func createIdentifier(for key: Data) -> String {
+        (genesisData.prefix(7) + key).toHex()
     }
 }

--- a/fearless/Modules/MainTabBar/MainTabBarInteractor.swift
+++ b/fearless/Modules/MainTabBar/MainTabBarInteractor.swift
@@ -10,6 +10,7 @@ final class MainTabBarInteractor {
     let settings: SettingsManagerProtocol
     let webSocketService: WebSocketServiceProtocol
     let runtimeService: RuntimeRegistryServiceProtocol
+    let validatorService: EraValidatorServiceProtocol
     let keystoreImportService: KeystoreImportServiceProtocol
     let gitHubPhishingAPIService: ApplicationServiceProtocol
 
@@ -25,11 +26,13 @@ final class MainTabBarInteractor {
          webSocketService: WebSocketServiceProtocol,
          gitHubPhishingAPIService: ApplicationServiceProtocol,
          runtimeService: RuntimeRegistryServiceProtocol,
+         validatorService: EraValidatorServiceProtocol,
          keystoreImportService: KeystoreImportServiceProtocol) {
         self.eventCenter = eventCenter
         self.settings = settings
         self.webSocketService = webSocketService
         self.runtimeService = runtimeService
+        self.validatorService = validatorService
         self.keystoreImportService = keystoreImportService
         self.gitHubPhishingAPIService = gitHubPhishingAPIService
 
@@ -47,12 +50,14 @@ final class MainTabBarInteractor {
         webSocketService.setup()
         gitHubPhishingAPIService.setup()
         runtimeService.setup()
+        validatorService.setup()
     }
 
     private func stopServices() {
         runtimeService.throttle()
         webSocketService.throttle()
         gitHubPhishingAPIService.throttle()
+        validatorService.throttle()
     }
 
     private func updateWebSocketSettings() {

--- a/fearless/Modules/MainTabBar/MainTabBarViewFactory.swift
+++ b/fearless/Modules/MainTabBar/MainTabBarViewFactory.swift
@@ -15,22 +15,12 @@ final class MainTabBarViewFactory: MainTabBarViewFactoryProtocol {
         }
 
         let localizationManager = LocalizationManager.shared
-        let webSocketService = WebSocketService.shared
-        webSocketService.networkStatusPresenter =
-            createNetworkStatusPresenter(localizationManager: localizationManager)
-        let gitHubPhishingAPIService = GitHubPhishingServiceFactory().createGitHubService()
 
-        let settings = SettingsManager.shared
-
-        let chain = settings.selectedConnection.type.chain
-        let validatorsService = EraValidatorFactory.createService(from: chain)
+        let serviceCoordinator = ServiceCoordinator.createDefault()
 
         let interactor = MainTabBarInteractor(eventCenter: EventCenter.shared,
-                                              settings: settings,
-                                              webSocketService: webSocketService,
-                                              gitHubPhishingAPIService: gitHubPhishingAPIService,
-                                              runtimeService: RuntimeRegistryFacade.sharedService,
-                                              validatorService: validatorsService,
+                                              settings: SettingsManager.shared,
+                                              serviceCoordinator: serviceCoordinator,
                                               keystoreImportService: keystoreImportService)
 
         guard
@@ -265,18 +255,5 @@ final class MainTabBarViewFactory: MainTabBarViewFactoryProtocol {
         tabBarItem.setTitleTextAttributes(selectedAttributes, for: .selected)
 
         return tabBarItem
-    }
-
-    static func createNetworkStatusPresenter(localizationManager: LocalizationManagerProtocol)
-        -> NetworkAvailabilityLayerInteractorOutputProtocol? {
-        guard let window = UIApplication.shared.keyWindow as? ApplicationStatusPresentable else {
-            return nil
-        }
-
-        let prenseter = NetworkAvailabilityLayerPresenter()
-        prenseter.localizationManager = localizationManager
-        prenseter.view = window
-
-        return prenseter
     }
 }

--- a/fearless/Modules/MainTabBar/MainTabBarViewFactory.swift
+++ b/fearless/Modules/MainTabBar/MainTabBarViewFactory.swift
@@ -20,11 +20,17 @@ final class MainTabBarViewFactory: MainTabBarViewFactoryProtocol {
             createNetworkStatusPresenter(localizationManager: localizationManager)
         let gitHubPhishingAPIService = GitHubPhishingServiceFactory().createGitHubService()
 
+        let settings = SettingsManager.shared
+
+        let chain = settings.selectedConnection.type.chain
+        let validatorsService = EraValidatorFactory.createService(from: chain)
+
         let interactor = MainTabBarInteractor(eventCenter: EventCenter.shared,
-                                              settings: SettingsManager.shared,
+                                              settings: settings,
                                               webSocketService: webSocketService,
                                               gitHubPhishingAPIService: gitHubPhishingAPIService,
                                               runtimeService: RuntimeRegistryFacade.sharedService,
+                                              validatorService: validatorsService,
                                               keystoreImportService: keystoreImportService)
 
         guard


### PR DESCRIPTION
- era validation service implementation add: main purpose is to fetch validators list when era changes and provide it to other services on request
- refactor service loading by introducing service coordinator and moving initialization of the services to the correponding factories
- add operations to create storage keys based on runtime: MapKeyEncodingOperation, DoubleMapKeyEncodingOperation
- add storage response decoding operation based on runtime
- add storage request factory to incapsulate pipeline: prepare key, get data, decode data