### PR TITLE
FLW-828 Fix "Payout confirmation" bottom view layout

### DIFF
--- a/fearless/Common/View/NetworkFeeConfirmView.swift
+++ b/fearless/Common/View/NetworkFeeConfirmView.swift
@@ -49,7 +49,7 @@ final class NetworkFeeConfirmView: UIView {
             make.height.equalTo(UIConstants.actionHeight)
             make.top.equalTo(networkFeeView.snp.bottom).offset(UIConstants.horizontalInset)
             make.leading.trailing.equalToSuperview().inset(UIConstants.horizontalInset)
-            make.bottom.equalTo(safeAreaLayoutGuide).inset(UIConstants.actionBottomInset)
+            make.bottom.equalTo(safeAreaLayoutGuide).inset(UIConstants.horizontalInset)
         }
     }
 }

--- a/fearless/Modules/Staking/StakingPayoutConfirmation/StakingPayoutConfirmationViewController.swift
+++ b/fearless/Modules/Staking/StakingPayoutConfirmation/StakingPayoutConfirmationViewController.swift
@@ -30,7 +30,8 @@ final class StakingPayoutConfirmationViewController: UIViewController, ViewHolde
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        setupInitialFeeView()
+        rootView.networkFeeConfirmView.actionButton
+            .addTarget(self, action: #selector(confirmAction), for: .touchUpInside)
         applyLocalization()
         setupTable()
         presenter.setup()
@@ -44,25 +45,6 @@ final class StakingPayoutConfirmationViewController: UIViewController, ViewHolde
 
     @objc
     private func presentPayoutOptionsAction() {}
-
-    private func setupInitialFeeView() {
-        let locale = localizationManager?.selectedLocale ?? Locale.current
-
-        let viewModel = ExtrinisicConfirmViewModel(
-            title: R.string.localizable.commonNetworkFee(preferredLanguages: locale.rLanguages),
-            amount: "",
-            price: nil,
-            icon: nil,
-            action: R.string.localizable.commonConfirm(preferredLanguages: locale.rLanguages),
-            numberOfLines: 1,
-            shouldAllowAction: true
-        )
-
-        rootView.payoutConfirmView.bind(viewModel: viewModel)
-
-        rootView.payoutConfirmView.actionButton
-            .addTarget(self, action: #selector(confirmAction), for: .touchUpInside)
-    }
 
     private func setupTable() {
         rootView.tableView.registerClassesForCell([
@@ -103,19 +85,8 @@ extension StakingPayoutConfirmationViewController: Localizable {
     }
 
     private func setupConfirmViewLocalization(_ locale: Locale) {
-        guard let feeViewModel = feeViewModel?.value(for: locale) else { return }
-
-        let viewModel = ExtrinisicConfirmViewModel(
-            title: R.string.localizable.commonNetworkFee(preferredLanguages: locale.rLanguages),
-            amount: feeViewModel.amount,
-            price: feeViewModel.price,
-            icon: nil,
-            action: R.string.localizable.commonConfirm(preferredLanguages: locale.rLanguages),
-            numberOfLines: 1,
-            shouldAllowAction: true
-        )
-
-        rootView.payoutConfirmView.bind(viewModel: viewModel)
+        let localizedViewModel = feeViewModel?.value(for: locale)
+        rootView.networkFeeConfirmView.networkFeeView.bind(viewModel: localizedViewModel)
     }
 
     func applyLocalization() {

--- a/fearless/Modules/Staking/StakingPayoutConfirmation/StakingPayoutConfirmationViewLayout.swift
+++ b/fearless/Modules/Staking/StakingPayoutConfirmation/StakingPayoutConfirmationViewLayout.swift
@@ -14,10 +14,7 @@ final class StakingPayoutConfirmationViewLayout: UIView {
         return tableView
     }()
 
-    let payoutConfirmView: TransferConfirmAccessoryView! = {
-        UINib(resource: R.nib.transferConfirmAccessoryView)
-            .instantiate(withOwner: nil, options: nil)[0] as? TransferConfirmAccessoryView
-    }()
+    let networkFeeConfirmView: NetworkFeeConfirmView = UIFactory().createNetworkFeeConfirmView()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -45,11 +42,9 @@ final class StakingPayoutConfirmationViewLayout: UIView {
             make.leading.bottom.trailing.equalToSuperview()
         }
 
-        let bottomViewHeight = Constants.bottomViewHeight - safeAreaInsets.bottom
-        addSubview(payoutConfirmView)
-        payoutConfirmView.snp.makeConstraints { make in
-            make.leading.trailing.bottom.equalToSuperview()
-            make.height.equalTo(bottomViewHeight)
+        addSubview(networkFeeConfirmView)
+        networkFeeConfirmView.snp.makeConstraints { make in
+            make.leading.bottom.trailing.equalToSuperview()
         }
     }
 }


### PR DESCRIPTION
**Before** iPhone 8
<img width="478" alt="before-iphone8" src="https://user-images.githubusercontent.com/17689921/118289328-e94f6a00-b4dd-11eb-8a5e-8f506d036f7f.png">
**After** iPhone 8
<img width="496" alt="after-iphone8" src="https://user-images.githubusercontent.com/17689921/118289506-16038180-b4de-11eb-863d-6c09817767f1.png">
**Before** iPhone 11
<img width="496" alt="before-iphone11" src="https://user-images.githubusercontent.com/17689921/118289568-29165180-b4de-11eb-9189-f8e9bb591055.png">
**After** iPhone 11
<img width="496" alt="after-iphone11" src="https://user-images.githubusercontent.com/17689921/118289609-34697d00-b4de-11eb-92ec-bd04968865b3.png">


