### PR TITLE
FLW-830 iOS: Add tap zone for Stake widget

### DIFF
--- a/fearless/Assets.xcassets/colorHighlightedPink.colorset/Contents.json
+++ b/fearless/Assets.xcassets/colorHighlightedPink.colorset/Contents.json
@@ -4,7 +4,7 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "0.500",
+          "alpha" : "0.300",
           "blue" : "0x9A",
           "green" : "0x00",
           "red" : "0xFF"

--- a/fearless/Assets.xcassets/colorHighlightedPink.colorset/Contents.json
+++ b/fearless/Assets.xcassets/colorHighlightedPink.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "0.500",
-          "blue" : "0.604",
-          "green" : "0.000",
-          "red" : "1.000"
+          "blue" : "0x9A",
+          "green" : "0x00",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"

--- a/fearless/Assets.xcassets/colorPink.colorset/Contents.json
+++ b/fearless/Assets.xcassets/colorPink.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.604",
-          "green" : "0.000",
-          "red" : "1.000"
+          "blue" : "0x9A",
+          "green" : "0x00",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"

--- a/fearless/Modules/Staking/StakingMain/View/NominationView.xib
+++ b/fearless/Modules/Staking/StakingMain/View/NominationView.xib
@@ -287,6 +287,14 @@
             <point key="canvasLocation" x="76.811594202898561" y="133.59375"/>
         </view>
     </objects>
+    <designables>
+        <designable name="eSO-sw-XgP">
+            <size key="intrinsicContentSize" width="16" height="16"/>
+        </designable>
+        <designable name="ty6-60-FB0">
+            <size key="intrinsicContentSize" width="16" height="16"/>
+        </designable>
+    </designables>
     <resources>
         <image name="iconHorMore" width="24" height="24"/>
         <image name="iconSmallArrow" width="24" height="24"/>
@@ -294,7 +302,7 @@
             <color red="0.054901960784313725" green="0.82745098039215681" blue="0.23137254901960785" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="colorHighlightedPink">
-            <color red="1" green="0.0" blue="0.60399997234344482" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="1" green="0.0" blue="0.60399997234344482" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="colorTransparentText">
             <color red="1" green="1" blue="1" alpha="0.63999998569488525" colorSpace="custom" customColorSpace="sRGB"/>

--- a/fearless/Modules/Staking/StakingMain/View/NominationView.xib
+++ b/fearless/Modules/Staking/StakingMain/View/NominationView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -35,85 +35,78 @@
                         </userDefinedRuntimeAttribute>
                     </userDefinedRuntimeAttributes>
                 </view>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GlX-Gb-MJn">
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ty6-60-FB0" userLabel="More button" customClass="TriangularedButton" customModule="fearless" customModuleProvider="target">
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="131"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="color" keyPath="_fillColor">
+                            <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="color" keyPath="_highlightedFillColor">
+                            <color key="value" name="colorHighlightedPink"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="color" keyPath="_strokeColor">
+                            <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="color" keyPath="_highlightedStrokeColor">
+                            <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="number" keyPath="_shadowOpacity">
+                            <real key="value" value="0.0"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="boolean" keyPath="_highlighted" value="NO"/>
+                        <userDefinedRuntimeAttribute type="number" keyPath="_cornerCut">
+                            <integer key="value" value="1"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                    <connections>
+                        <action selector="actionOnMore" destination="iN0-l3-epB" eventType="touchUpInside" id="3vL-9A-vdr"/>
+                    </connections>
+                </view>
+                <view userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GlX-Gb-MJn">
                     <rect key="frame" x="0.0" y="0.0" width="414" height="131"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Staking" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qWM-dm-mLK">
-                            <rect key="frame" x="16" y="15" width="47.5" height="16.5"/>
+                            <rect key="frame" x="16" y="15" width="56" height="18"/>
                             <fontDescription key="fontDescription" name="sora-rc004-0417-Bold" family="sora-rc004-0417" pointSize="14"/>
                             <color key="textColor" name="colorWhite"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hsh-WU-SOM" customClass="RoundedButton" customModule="SoraUI">
-                            <rect key="frame" x="358" y="-5" width="56" height="56.5"/>
-                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            <userDefinedRuntimeAttributes>
-                                <userDefinedRuntimeAttribute type="image" keyPath="_iconImage" value="iconHorMore"/>
-                                <userDefinedRuntimeAttribute type="color" keyPath="_fillColor">
-                                    <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                </userDefinedRuntimeAttribute>
-                                <userDefinedRuntimeAttribute type="color" keyPath="_highlightedFillColor">
-                                    <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                </userDefinedRuntimeAttribute>
-                                <userDefinedRuntimeAttribute type="color" keyPath="_strokeColor">
-                                    <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                </userDefinedRuntimeAttribute>
-                                <userDefinedRuntimeAttribute type="color" keyPath="_highlightedStrokeColor">
-                                    <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                </userDefinedRuntimeAttribute>
-                                <userDefinedRuntimeAttribute type="number" keyPath="_shadowOpacity">
-                                    <real key="value" value="0.0"/>
-                                </userDefinedRuntimeAttribute>
-                                <userDefinedRuntimeAttribute type="number" keyPath="_rightInset">
-                                    <real key="value" value="16"/>
-                                </userDefinedRuntimeAttribute>
-                                <userDefinedRuntimeAttribute type="number" keyPath="_leftInset">
-                                    <real key="value" value="16"/>
-                                </userDefinedRuntimeAttribute>
-                                <userDefinedRuntimeAttribute type="number" keyPath="_bottomInset">
-                                    <real key="value" value="16"/>
-                                </userDefinedRuntimeAttribute>
-                                <userDefinedRuntimeAttribute type="number" keyPath="_topInset">
-                                    <real key="value" value="16"/>
-                                </userDefinedRuntimeAttribute>
-                                <userDefinedRuntimeAttribute type="boolean" keyPath="_changesContentOpacityWhenHighlighted" value="YES"/>
-                            </userDefinedRuntimeAttributes>
-                            <connections>
-                                <action selector="actionOnMore" destination="iN0-l3-epB" eventType="touchUpInside" id="zUq-hm-bzI"/>
-                            </connections>
-                        </view>
+                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="iconHorMore" translatesAutoresizingMaskIntoConstraints="NO" id="WOg-aC-Mcs">
+                            <rect key="frame" x="374" y="12" width="24" height="24"/>
+                        </imageView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$812" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fhk-jh-pW9">
-                            <rect key="frame" x="16" y="92" width="191" height="14"/>
+                            <rect key="frame" x="16" y="90.5" width="191" height="15.5"/>
                             <fontDescription key="fontDescription" name="sora-rc004-0417-Regular" family="sora-rc004-0417" pointSize="12"/>
                             <color key="textColor" name="colorTransparentText"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="10.00003 KSM" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4pA-EK-QHl">
-                            <rect key="frame" x="16" y="65" width="191" height="25"/>
+                            <rect key="frame" x="16" y="68" width="191" height="20.5"/>
                             <fontDescription key="fontDescription" name="sora-rc004-0417-Regular" family="sora-rc004-0417" pointSize="16"/>
                             <color key="textColor" name="colorWhite"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="Total staked" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="twS-ZJ-9RP">
-                            <rect key="frame" x="16" y="47" width="191" height="14"/>
+                            <rect key="frame" x="16" y="48.5" width="191" height="15.5"/>
                             <fontDescription key="fontDescription" name="sora-rc004-0417-Regular" family="sora-rc004-0417" pointSize="12"/>
                             <color key="textColor" name="colorTransparentText"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="0.45 KSM" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rFT-3I-w8w">
-                            <rect key="frame" x="207" y="65" width="191" height="25"/>
+                            <rect key="frame" x="207" y="68" width="191" height="20.5"/>
                             <fontDescription key="fontDescription" name="sora-rc004-0417-Regular" family="sora-rc004-0417" pointSize="16"/>
                             <color key="textColor" name="colorWhite"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="Total rewards" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ABS-p6-AK0">
-                            <rect key="frame" x="207" y="47" width="191" height="14"/>
+                            <rect key="frame" x="207" y="48.5" width="191" height="15.5"/>
                             <fontDescription key="fontDescription" name="sora-rc004-0417-Regular" family="sora-rc004-0417" pointSize="12"/>
                             <color key="textColor" name="colorTransparentText"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$40.51" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="utf-CN-3GC">
-                            <rect key="frame" x="207" y="92" width="191" height="14"/>
+                            <rect key="frame" x="207" y="90.5" width="191" height="15.5"/>
                             <fontDescription key="fontDescription" name="sora-rc004-0417-Regular" family="sora-rc004-0417" pointSize="12"/>
                             <color key="textColor" name="colorTransparentText"/>
                             <nil key="highlightedColor"/>
@@ -121,22 +114,22 @@
                     </subviews>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
-                        <constraint firstAttribute="trailing" secondItem="hsh-WU-SOM" secondAttribute="trailing" id="0d8-iA-JVL"/>
                         <constraint firstItem="Fhk-jh-pW9" firstAttribute="leading" secondItem="GlX-Gb-MJn" secondAttribute="leading" constant="16" id="1Pz-nG-CYl"/>
                         <constraint firstItem="qWM-dm-mLK" firstAttribute="top" secondItem="GlX-Gb-MJn" secondAttribute="top" constant="15" id="7eT-mA-s9w"/>
                         <constraint firstItem="ABS-p6-AK0" firstAttribute="leading" secondItem="rFT-3I-w8w" secondAttribute="leading" id="8lU-Di-mw2"/>
                         <constraint firstItem="4pA-EK-QHl" firstAttribute="top" secondItem="twS-ZJ-9RP" secondAttribute="bottom" constant="4" id="Cle-G2-z17"/>
+                        <constraint firstAttribute="trailing" secondItem="WOg-aC-Mcs" secondAttribute="trailing" constant="16" id="FCP-PF-ZgO"/>
                         <constraint firstItem="rFT-3I-w8w" firstAttribute="leading" secondItem="utf-CN-3GC" secondAttribute="leading" id="KN1-Gg-TZx"/>
                         <constraint firstItem="qWM-dm-mLK" firstAttribute="leading" secondItem="GlX-Gb-MJn" secondAttribute="leading" constant="16" id="KXv-WB-I8h"/>
                         <constraint firstItem="4pA-EK-QHl" firstAttribute="trailing" secondItem="Fhk-jh-pW9" secondAttribute="trailing" id="NBK-kP-4Ua"/>
                         <constraint firstItem="ABS-p6-AK0" firstAttribute="top" secondItem="qWM-dm-mLK" secondAttribute="bottom" constant="15.5" id="NLL-Ej-F5F"/>
+                        <constraint firstItem="WOg-aC-Mcs" firstAttribute="centerY" secondItem="qWM-dm-mLK" secondAttribute="centerY" id="Pug-JM-sul"/>
                         <constraint firstItem="twS-ZJ-9RP" firstAttribute="leading" secondItem="4pA-EK-QHl" secondAttribute="leading" id="Vvl-EQ-aJ3"/>
                         <constraint firstAttribute="bottom" secondItem="Fhk-jh-pW9" secondAttribute="bottom" constant="25" id="Wp0-Md-EgC"/>
                         <constraint firstItem="rFT-3I-w8w" firstAttribute="trailing" secondItem="utf-CN-3GC" secondAttribute="trailing" id="XCb-ul-Wbs"/>
                         <constraint firstAttribute="bottom" secondItem="utf-CN-3GC" secondAttribute="bottom" constant="25" id="Z5C-mL-ilU"/>
                         <constraint firstItem="Fhk-jh-pW9" firstAttribute="trailing" secondItem="GlX-Gb-MJn" secondAttribute="centerX" id="d2l-4a-IvE"/>
                         <constraint firstItem="twS-ZJ-9RP" firstAttribute="top" secondItem="qWM-dm-mLK" secondAttribute="bottom" constant="15.5" id="eHA-5M-24Z"/>
-                        <constraint firstItem="hsh-WU-SOM" firstAttribute="centerY" secondItem="qWM-dm-mLK" secondAttribute="centerY" id="gOq-Ne-bVx"/>
                         <constraint firstItem="ABS-p6-AK0" firstAttribute="trailing" secondItem="rFT-3I-w8w" secondAttribute="trailing" id="giV-Pi-Shj"/>
                         <constraint firstAttribute="trailing" secondItem="utf-CN-3GC" secondAttribute="trailing" constant="16" id="mMc-Hp-Mk8"/>
                         <constraint firstItem="utf-CN-3GC" firstAttribute="top" secondItem="rFT-3I-w8w" secondAttribute="bottom" constant="2" id="msE-Ml-Rwg"/>
@@ -155,7 +148,7 @@
                             <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </userDefinedRuntimeAttribute>
                         <userDefinedRuntimeAttribute type="color" keyPath="_highlightedFillColor">
-                            <color key="value" name="colorPink"/>
+                            <color key="value" name="colorHighlightedPink"/>
                         </userDefinedRuntimeAttribute>
                         <userDefinedRuntimeAttribute type="color" keyPath="_strokeColor">
                             <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -198,13 +191,13 @@
                             </userDefinedRuntimeAttributes>
                         </view>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="ACTIVE" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6Yr-ex-mku">
-                            <rect key="frame" x="16" y="17" width="34.5" height="12"/>
+                            <rect key="frame" x="16" y="16.5" width="38.5" height="13"/>
                             <fontDescription key="fontDescription" name="sora-rc004-0417-Bold" family="sora-rc004-0417" pointSize="10"/>
                             <color key="textColor" name="colorGreen"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="ERA #1498" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dJM-N2-P95">
-                            <rect key="frame" x="58.5" y="17" width="297.5" height="12"/>
+                            <rect key="frame" x="62.5" y="16.5" width="293.5" height="13"/>
                             <fontDescription key="fontDescription" name="sora-rc004-0417-Bold" family="sora-rc004-0417" pointSize="10"/>
                             <color key="textColor" red="1" green="1" blue="1" alpha="0.64000000000000001" colorSpace="custom" customColorSpace="calibratedRGB"/>
                             <nil key="highlightedColor"/>
@@ -261,12 +254,18 @@
                 <constraint firstAttribute="trailing" secondItem="qHg-H6-Zvj" secondAttribute="trailing" id="8Nn-6M-vZR"/>
                 <constraint firstItem="eSO-sw-XgP" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="Bk8-CY-e5S"/>
                 <constraint firstItem="eSO-sw-XgP" firstAttribute="top" secondItem="fMa-jf-RbY" secondAttribute="top" id="HA3-eX-uOG"/>
+                <constraint firstItem="ty6-60-FB0" firstAttribute="bottom" secondItem="GlX-Gb-MJn" secondAttribute="bottom" id="LUB-1L-WHC"/>
                 <constraint firstItem="GlX-Gb-MJn" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="OLL-K3-dSn"/>
                 <constraint firstItem="fMa-jf-RbY" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="16" id="Rhd-pV-m6y"/>
                 <constraint firstAttribute="bottom" secondItem="eSO-sw-XgP" secondAttribute="bottom" id="Zn2-qo-k76"/>
+                <constraint firstItem="ty6-60-FB0" firstAttribute="leading" secondItem="GlX-Gb-MJn" secondAttribute="leading" id="bR5-30-x8h"/>
                 <constraint firstItem="qHg-H6-Zvj" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="cvw-cC-kaB"/>
+                <constraint firstItem="ty6-60-FB0" firstAttribute="centerX" secondItem="GlX-Gb-MJn" secondAttribute="centerX" id="fa2-oT-6gD"/>
+                <constraint firstItem="ty6-60-FB0" firstAttribute="trailing" secondItem="GlX-Gb-MJn" secondAttribute="trailing" id="hJF-59-Icm"/>
                 <constraint firstItem="fMa-jf-RbY" firstAttribute="top" secondItem="GlX-Gb-MJn" secondAttribute="bottom" id="jgT-eH-Z2G"/>
                 <constraint firstAttribute="bottom" secondItem="qHg-H6-Zvj" secondAttribute="bottom" id="mNc-Cm-Deq"/>
+                <constraint firstItem="ty6-60-FB0" firstAttribute="centerY" secondItem="GlX-Gb-MJn" secondAttribute="centerY" id="mip-4M-7TX"/>
+                <constraint firstItem="ty6-60-FB0" firstAttribute="top" secondItem="GlX-Gb-MJn" secondAttribute="top" id="pSa-wJ-a0l"/>
                 <constraint firstAttribute="trailing" secondItem="eSO-sw-XgP" secondAttribute="trailing" id="wLr-VT-Rny"/>
                 <constraint firstAttribute="bottom" secondItem="fMa-jf-RbY" secondAttribute="bottom" id="yY2-jr-qqC"/>
             </constraints>
@@ -278,7 +277,7 @@
                 <outlet property="stakedAmountLabel" destination="4pA-EK-QHl" id="fwn-oO-8gb"/>
                 <outlet property="stakedPriceLabel" destination="Fhk-jh-pW9" id="AUu-jY-je0"/>
                 <outlet property="stakedTitleLabel" destination="twS-ZJ-9RP" id="QJp-lD-uG8"/>
-                <outlet property="statusButton" destination="eSO-sw-XgP" id="iug-JZ-LuL"/>
+                <outlet property="statusButton" destination="eSO-sw-XgP" id="S9h-kF-5Gn"/>
                 <outlet property="statusDetailsLabel" destination="dJM-N2-P95" id="sbg-RR-4VT"/>
                 <outlet property="statusIndicatorView" destination="dWB-k1-miH" id="aU2-YM-UB5"/>
                 <outlet property="statusNavigationView" destination="76R-Oj-nF6" id="4KZ-cd-eDr"/>
@@ -288,22 +287,14 @@
             <point key="canvasLocation" x="76.811594202898561" y="133.59375"/>
         </view>
     </objects>
-    <designables>
-        <designable name="eSO-sw-XgP">
-            <size key="intrinsicContentSize" width="16" height="16"/>
-        </designable>
-        <designable name="hsh-WU-SOM">
-            <size key="intrinsicContentSize" width="56" height="56"/>
-        </designable>
-    </designables>
     <resources>
         <image name="iconHorMore" width="24" height="24"/>
         <image name="iconSmallArrow" width="24" height="24"/>
         <namedColor name="colorGreen">
-            <color red="0.054999999701976776" green="0.82700002193450928" blue="0.23100000619888306" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.054901960784313725" green="0.82745098039215681" blue="0.23137254901960785" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
-        <namedColor name="colorPink">
-            <color red="1" green="0.0" blue="0.60399997234344482" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        <namedColor name="colorHighlightedPink">
+            <color red="1" green="0.0" blue="0.60399997234344482" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="colorTransparentText">
             <color red="1" green="1" blue="1" alpha="0.63999998569488525" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
- extend tap zone to cover all the widget area
- reduce highlight opacity to 30%