### PR TITLE
Fix oversubscribed

### DIFF
--- a/fearless/Common/Services/EraValidatorsService/EraValidatorService+Fetch.swift
+++ b/fearless/Common/Services/EraValidatorsService/EraValidatorService+Fetch.swift
@@ -26,9 +26,15 @@ extension EraValidatorService {
                 return nil
             }
 
+            let exposure = ValidatorExposure(
+                total: item.1.total,
+                own: item.1.own,
+                others: item.1.others.sorted { $0.value > $1.value }
+            )
+
             return EraValidatorInfo(
                 accountId: item.0,
-                exposure: item.1,
+                exposure: exposure,
                 prefs: pref
             )
         }

--- a/fearless/Common/Substrate/Types/ValidatorExposure.swift
+++ b/fearless/Common/Substrate/Types/ValidatorExposure.swift
@@ -12,3 +12,9 @@ struct IndividualExposure: Codable {
     let who: Data
     @StringCodable var value: BigUInt
 }
+
+extension ValidatorExposure {
+    func clippedNominators(for limit: UInt32) -> [IndividualExposure] {
+        Array(others.sorted(by: { $0.value > $1.value }).prefix(Int(limit)))
+    }
+}

--- a/fearless/Common/Substrate/Types/ValidatorExposure.swift
+++ b/fearless/Common/Substrate/Types/ValidatorExposure.swift
@@ -12,9 +12,3 @@ struct IndividualExposure: Codable {
     let who: Data
     @StringCodable var value: BigUInt
 }
-
-extension ValidatorExposure {
-    func clippedNominators(for limit: UInt32) -> [IndividualExposure] {
-        Array(others.sorted(by: { $0.value > $1.value }).prefix(Int(limit)))
-    }
-}

--- a/fearless/Modules/Staking/Operations/NetworkStakingInfoOperationFactory.swift
+++ b/fearless/Modules/Staking/Operations/NetworkStakingInfoOperationFactory.swift
@@ -47,7 +47,7 @@ final class NetworkStakingInfoOperationFactory {
         from eraStakersInfo: EraStakersInfo,
         limitedBy maxNominators: Int
     ) -> BigUInt {
-        eraStakersInfo.validators.map { $0.exposure.others.sorted { $0.value > $1.value } }
+        eraStakersInfo.validators.map(\.exposure.others)
             .flatMap { Array($0.prefix(maxNominators)) }
             .reduce(into: [Data: BigUInt]()) { result, item in
                 if let maybeStake = result[item.who], let stake = maybeStake {
@@ -64,7 +64,7 @@ final class NetworkStakingInfoOperationFactory {
         from eraStakersInfo: EraStakersInfo,
         limitedBy maxNominators: Int
     ) -> Int {
-        eraStakersInfo.validators.map { $0.exposure.others.sorted { $0.value > $1.value } }
+        eraStakersInfo.validators.map(\.exposure.others)
             .flatMap { Array($0.prefix(maxNominators)) }
             .reduce(into: Set<Data>()) { $0.insert($1.who) }
             .count

--- a/fearless/Modules/Staking/Operations/ValidatorOperationFactory.swift
+++ b/fearless/Modules/Staking/Operations/ValidatorOperationFactory.swift
@@ -130,8 +130,7 @@ final class ValidatorOperationFactory {
 
                 if let electedValidator = allElectedValidators.validators
                     .first(where: { $0.accountId == accountId }) {
-                    let exposuresClipped = electedValidator.exposure.others.sorted(by: { $0.value > $1.value })
-                        .prefix(Int(maxNominators))
+                    let exposuresClipped = electedValidator.exposure.others.prefix(Int(maxNominators))
                     if let amount = exposuresClipped.first(where: { $0.who == nominatorId })?.value,
                        let amountDecimal = Decimal.fromSubstrateAmount(amount, precision: addressType.precision) {
                         return .active(amount: amountDecimal)
@@ -254,7 +253,6 @@ final class ValidatorOperationFactory {
             return try electedStakers.validators
                 .reduce(into: [AccountId: ValidatorStakeInfo]()) { result, validator in
                     let exposures = validator.exposure.others
-                        .sorted { $0.value > $1.value }
                         .prefix(Int(maxNominatorsRewarded))
 
                     guard exposures.contains(where: { $0.who == nominatorAccountId }) else {

--- a/fearless/Modules/Staking/StakingMain/StakingMainInteractor+InputProtocol.swift
+++ b/fearless/Modules/Staking/StakingMain/StakingMainInteractor+InputProtocol.swift
@@ -9,6 +9,7 @@ extension StakingMainInteractor: StakingMainInteractorInputProtocol {
 
         provideNewChain()
         provideSelectedAccount()
+        provideMaxNominatorsPerValidator()
 
         subscribeToPriceChanges()
         subscribeToAccountChanges()
@@ -60,6 +61,7 @@ extension StakingMainInteractor: EventVisitorProtocol {
             provideEraStakersInfo()
             provideNetworkStakingInfo()
             provideRewardCalculator()
+            provideMaxNominatorsPerValidator()
         }
     }
 

--- a/fearless/Modules/Staking/StakingMain/StakingMainInteractor.swift
+++ b/fearless/Modules/Staking/StakingMain/StakingMainInteractor.swift
@@ -4,7 +4,7 @@ import RobinHood
 import FearlessUtils
 import SoraFoundation
 
-final class StakingMainInteractor {
+final class StakingMainInteractor: RuntimeConstantFetching {
     weak var presenter: StakingMainInteractorOutputProtocol!
 
     let providerFactory: SingleValueProviderFactoryProtocol
@@ -70,6 +70,16 @@ final class StakingMainInteractor {
         }
 
         presenter.didReceive(selectedAddress: address)
+    }
+
+    func provideMaxNominatorsPerValidator() {
+        fetchConstant(
+            for: .maxNominatorRewardedPerValidator,
+            runtimeCodingService: runtimeService,
+            operationManager: operationManager
+        ) { [weak self] result in
+            self?.presenter.didReceiveMaxNominatorsPerValidator(result: result)
+        }
     }
 
     func provideNewChain() {

--- a/fearless/Modules/Staking/StakingMain/StakingMainPresenter.swift
+++ b/fearless/Modules/Staking/StakingMain/StakingMainPresenter.swift
@@ -438,6 +438,15 @@ extension StakingMainPresenter: StakingMainInteractorOutputProtocol {
         controllerAccount = nil
         handle(error: fetchControllerError)
     }
+
+    func didReceiveMaxNominatorsPerValidator(result: Result<UInt32, Error>) {
+        switch result {
+        case let .success(maxNominatorsPerValidator):
+            stateMachine.state.process(maxNominatorsPerValidator: maxNominatorsPerValidator)
+        case let .failure(error):
+            handle(error: error)
+        }
+    }
 }
 
 extension StakingMainPresenter: ModalPickerViewControllerDelegate {

--- a/fearless/Modules/Staking/StakingMain/StakingMainProtocols.swift
+++ b/fearless/Modules/Staking/StakingMain/StakingMainProtocols.swift
@@ -59,6 +59,8 @@ protocol StakingMainInteractorOutputProtocol: AnyObject {
     func didReceive(payeeError: Error)
     func didReceive(newChain: Chain)
 
+    func didReceiveMaxNominatorsPerValidator(result: Result<UInt32, Error>)
+
     func didFetchController(_ controller: AccountItem?, for address: AccountAddress)
     func didReceive(fetchControllerError: Error)
 }

--- a/fearless/Modules/Staking/StakingMain/StateMachine/StakingStateMachineProtocols.swift
+++ b/fearless/Modules/Staking/StakingMain/StateMachine/StakingStateMachineProtocols.swift
@@ -31,6 +31,7 @@ protocol StakingStateProtocol {
     func process(totalReward: TotalRewardItem?)
     func process(payee: RewardDestinationArg?)
     func process(minimalStake: BigUInt?)
+    func process(maxNominatorsPerValidator: UInt32?)
 }
 
 protocol StakingStateMachineProtocol: AnyObject {

--- a/fearless/Modules/Staking/StakingMain/StateMachine/States/BaseStakingState.swift
+++ b/fearless/Modules/Staking/StakingMain/StateMachine/States/BaseStakingState.swift
@@ -88,6 +88,12 @@ class BaseStakingState: StakingStateProtocol {
         stateMachine?.transit(to: self)
     }
 
+    func process(maxNominatorsPerValidator: UInt32?) {
+        commonData = commonData.byReplacing(maxNominatorsPerValidator: maxNominatorsPerValidator)
+
+        stateMachine?.transit(to: self)
+    }
+
     func process(rewardEstimationAmount _: Decimal?) {}
     func process(stashItem _: StashItem?) {}
     func process(ledgerInfo _: StakingLedger?) {}

--- a/fearless/Modules/Staking/StakingMain/StateMachine/States/StakingStateCommonData.swift
+++ b/fearless/Modules/Staking/StakingMain/StateMachine/States/StakingStateCommonData.swift
@@ -10,6 +10,7 @@ struct StakingStateCommonData {
     let electionStatus: ElectionStatus?
     let eraStakersInfo: EraStakersInfo?
     let minimalStake: BigUInt?
+    let maxNominatorsPerValidator: UInt32?
 }
 
 extension StakingStateCommonData {
@@ -22,7 +23,8 @@ extension StakingStateCommonData {
             calculatorEngine: nil,
             electionStatus: nil,
             eraStakersInfo: nil,
-            minimalStake: nil
+            minimalStake: nil,
+            maxNominatorsPerValidator: nil
         )
     }
 
@@ -35,7 +37,8 @@ extension StakingStateCommonData {
             calculatorEngine: calculatorEngine,
             electionStatus: electionStatus,
             eraStakersInfo: eraStakersInfo,
-            minimalStake: minimalStake
+            minimalStake: minimalStake,
+            maxNominatorsPerValidator: maxNominatorsPerValidator
         )
     }
 
@@ -48,7 +51,8 @@ extension StakingStateCommonData {
             calculatorEngine: calculatorEngine,
             electionStatus: electionStatus,
             eraStakersInfo: eraStakersInfo,
-            minimalStake: minimalStake
+            minimalStake: minimalStake,
+            maxNominatorsPerValidator: maxNominatorsPerValidator
         )
     }
 
@@ -61,7 +65,8 @@ extension StakingStateCommonData {
             calculatorEngine: calculatorEngine,
             electionStatus: electionStatus,
             eraStakersInfo: eraStakersInfo,
-            minimalStake: minimalStake
+            minimalStake: minimalStake,
+            maxNominatorsPerValidator: maxNominatorsPerValidator
         )
     }
 
@@ -74,7 +79,8 @@ extension StakingStateCommonData {
             calculatorEngine: calculatorEngine,
             electionStatus: electionStatus,
             eraStakersInfo: eraStakersInfo,
-            minimalStake: minimalStake
+            minimalStake: minimalStake,
+            maxNominatorsPerValidator: maxNominatorsPerValidator
         )
     }
 
@@ -87,7 +93,8 @@ extension StakingStateCommonData {
             calculatorEngine: calculatorEngine,
             electionStatus: electionStatus,
             eraStakersInfo: eraStakersInfo,
-            minimalStake: minimalStake
+            minimalStake: minimalStake,
+            maxNominatorsPerValidator: maxNominatorsPerValidator
         )
     }
 
@@ -100,7 +107,8 @@ extension StakingStateCommonData {
             calculatorEngine: calculatorEngine,
             electionStatus: electionStatus,
             eraStakersInfo: eraStakersInfo,
-            minimalStake: minimalStake
+            minimalStake: minimalStake,
+            maxNominatorsPerValidator: maxNominatorsPerValidator
         )
     }
 
@@ -113,7 +121,8 @@ extension StakingStateCommonData {
             calculatorEngine: calculatorEngine,
             electionStatus: electionStatus,
             eraStakersInfo: eraStakersInfo,
-            minimalStake: minimalStake
+            minimalStake: minimalStake,
+            maxNominatorsPerValidator: maxNominatorsPerValidator
         )
     }
 
@@ -126,7 +135,22 @@ extension StakingStateCommonData {
             calculatorEngine: calculatorEngine,
             electionStatus: electionStatus,
             eraStakersInfo: eraStakersInfo,
-            minimalStake: minimalStake
+            minimalStake: minimalStake,
+            maxNominatorsPerValidator: maxNominatorsPerValidator
+        )
+    }
+
+    func byReplacing(maxNominatorsPerValidator: UInt32?) -> StakingStateCommonData {
+        StakingStateCommonData(
+            address: address,
+            chain: chain,
+            accountInfo: accountInfo,
+            price: price,
+            calculatorEngine: calculatorEngine,
+            electionStatus: electionStatus,
+            eraStakersInfo: eraStakersInfo,
+            minimalStake: minimalStake,
+            maxNominatorsPerValidator: maxNominatorsPerValidator
         )
     }
 }

--- a/fearlessTests/Mocks/ModuleMocks.swift
+++ b/fearlessTests/Mocks/ModuleMocks.swift
@@ -23073,6 +23073,21 @@ import SoraFoundation
     
     
     
+     func didReceiveMaxNominatorsPerValidator(result: Result<UInt32, Error>)  {
+        
+    return cuckoo_manager.call("didReceiveMaxNominatorsPerValidator(result: Result<UInt32, Error>)",
+            parameters: (result),
+            escapingParameters: (result),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.didReceiveMaxNominatorsPerValidator(result: result))
+        
+    }
+    
+    
+    
      func didFetchController(_ controller: AccountItem?, for address: AccountAddress)  {
         
     return cuckoo_manager.call("didFetchController(_: AccountItem?, for: AccountAddress)",
@@ -23238,6 +23253,11 @@ import SoraFoundation
 	    func didReceive<M1: Cuckoo.Matchable>(newChain: M1) -> Cuckoo.ProtocolStubNoReturnFunction<(Chain)> where M1.MatchedType == Chain {
 	        let matchers: [Cuckoo.ParameterMatcher<(Chain)>] = [wrap(matchable: newChain) { $0 }]
 	        return .init(stub: cuckoo_manager.createStub(for: MockStakingMainInteractorOutputProtocol.self, method: "didReceive(newChain: Chain)", parameterMatchers: matchers))
+	    }
+	    
+	    func didReceiveMaxNominatorsPerValidator<M1: Cuckoo.Matchable>(result: M1) -> Cuckoo.ProtocolStubNoReturnFunction<(Result<UInt32, Error>)> where M1.MatchedType == Result<UInt32, Error> {
+	        let matchers: [Cuckoo.ParameterMatcher<(Result<UInt32, Error>)>] = [wrap(matchable: result) { $0 }]
+	        return .init(stub: cuckoo_manager.createStub(for: MockStakingMainInteractorOutputProtocol.self, method: "didReceiveMaxNominatorsPerValidator(result: Result<UInt32, Error>)", parameterMatchers: matchers))
 	    }
 	    
 	    func didFetchController<M1: Cuckoo.OptionalMatchable, M2: Cuckoo.Matchable>(_ controller: M1, for address: M2) -> Cuckoo.ProtocolStubNoReturnFunction<(AccountItem?, AccountAddress)> where M1.OptionalMatchedType == AccountItem, M2.MatchedType == AccountAddress {
@@ -23423,6 +23443,12 @@ import SoraFoundation
 	    }
 	    
 	    @discardableResult
+	    func didReceiveMaxNominatorsPerValidator<M1: Cuckoo.Matchable>(result: M1) -> Cuckoo.__DoNotUse<(Result<UInt32, Error>), Void> where M1.MatchedType == Result<UInt32, Error> {
+	        let matchers: [Cuckoo.ParameterMatcher<(Result<UInt32, Error>)>] = [wrap(matchable: result) { $0 }]
+	        return cuckoo_manager.verify("didReceiveMaxNominatorsPerValidator(result: Result<UInt32, Error>)", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+	    }
+	    
+	    @discardableResult
 	    func didFetchController<M1: Cuckoo.OptionalMatchable, M2: Cuckoo.Matchable>(_ controller: M1, for address: M2) -> Cuckoo.__DoNotUse<(AccountItem?, AccountAddress), Void> where M1.OptionalMatchedType == AccountItem, M2.MatchedType == AccountAddress {
 	        let matchers: [Cuckoo.ParameterMatcher<(AccountItem?, AccountAddress)>] = [wrap(matchable: controller) { $0.0 }, wrap(matchable: address) { $0.1 }]
 	        return cuckoo_manager.verify("didFetchController(_: AccountItem?, for: AccountAddress)", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
@@ -23544,6 +23570,10 @@ import SoraFoundation
     }
     
      func didReceive(newChain: Chain)   {
+        return DefaultValueRegistry.defaultValue(for: (Void).self)
+    }
+    
+     func didReceiveMaxNominatorsPerValidator(result: Result<UInt32, Error>)   {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
     


### PR DESCRIPTION
- fix case when stake of nominator is distributed across multiple oversubscribed validators
- store nominator in exposure as a sorted list and not repeat sorting to get clipped nominators set