### PR TITLE
fix websocket packets type

### DIFF
--- a/fearless/Common/Network/JSONRPC/WebSocketEngine.swift
+++ b/fearless/Common/Network/JSONRPC/WebSocketEngine.swift
@@ -240,7 +240,7 @@ extension WebSocketEngine {
     func send(request: JSONRPCRequest) {
         inProgressRequests[request.requestId] = request
 
-        connection.write(data: request.data, completion: nil)
+        connection.write(stringData: request.data, completion: nil)
     }
 
     func sendAllPendingRequests() {


### PR DESCRIPTION
Patract nodes currently accepts only text frame which other nodes accepts both binary and text