### PR TITLE
FLW-991 iOS: Your validators. Add spinner during info loading. Retry is not working.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ platform :ios, '11.0'
 abstract_target 'fearlessAll' do
   use_frameworks!
 
-  pod 'FearlessUtils', :git => 'https://github.com/soramitsu/fearless-utils-iOS.git', :commit => '08bf127ebcda8821541c961e756e8f95b15166af'
+  pod 'FearlessUtils', '~> 0.11.0'
   pod 'SwiftLint'
   pod 'R.swift', :inhibit_warnings => true
   pod 'SoraKeystore'
@@ -25,7 +25,7 @@ abstract_target 'fearlessAll' do
     inherit! :search_paths
 
     pod 'Cuckoo'
-    pod 'FearlessUtils', :git => 'https://github.com/soramitsu/fearless-utils-iOS.git', :commit => '08bf127ebcda8821541c961e756e8f95b15166af'
+    pod 'FearlessUtils', '~> 0.11.0'
     pod 'SoraFoundation', '~> 0.10.0'
     pod 'R.swift', :inhibit_warnings => true
     pod 'FireMock', :inhibit_warnings => true

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -13,29 +13,33 @@ PODS:
   - Cuckoo (1.5.0):
     - Cuckoo/Swift (= 1.5.0)
   - Cuckoo/Swift (1.5.0)
-  - FearlessUtils (0.10.0):
+  - FearlessUtils (0.11.0):
     - BigInt (~> 5.0)
-    - IrohaCrypto/ed25519 (~> 0.7.0)
-    - IrohaCrypto/Scrypt (~> 0.7.0)
-    - IrohaCrypto/secp256k1 (~> 0.7.0)
-    - IrohaCrypto/sr25519 (~> 0.7.0)
+    - IrohaCrypto/ed25519 (~> 0.8.0)
+    - IrohaCrypto/Scrypt (~> 0.8.0)
+    - IrohaCrypto/secp256k1 (~> 0.8.0)
+    - IrohaCrypto/sr25519 (~> 0.8.0)
+    - IrohaCrypto/ss58 (~> 0.8.0)
     - TweetNacl (~> 1.0.0)
     - xxHash-Swift (~> 1.0.0)
   - FireMock (3.1)
-  - IrohaCrypto/BIP39 (0.7.4):
+  - IrohaCrypto/BIP39 (0.8.0):
     - IrohaCrypto/Common
-  - IrohaCrypto/blake2 (0.7.4)
-  - IrohaCrypto/Common (0.7.4)
-  - IrohaCrypto/ed25519 (0.7.4):
+  - IrohaCrypto/blake2 (0.8.0)
+  - IrohaCrypto/Common (0.8.0)
+  - IrohaCrypto/ed25519 (0.8.0):
     - IrohaCrypto/Common
-  - IrohaCrypto/Scrypt (0.7.4):
+  - IrohaCrypto/Scrypt (0.8.0):
     - IrohaCrypto/Common
     - scrypt.c (~> 0.1)
-  - IrohaCrypto/secp256k1 (0.7.4):
+  - IrohaCrypto/secp256k1 (0.8.0):
     - IrohaCrypto/Common
     - secp256k1.c (~> 0.1)
-  - IrohaCrypto/sr25519 (0.7.4):
+  - IrohaCrypto/sr25519 (0.8.0):
     - IrohaCrypto/BIP39
+    - IrohaCrypto/blake2
+    - IrohaCrypto/Common
+  - IrohaCrypto/ss58 (0.8.0):
     - IrohaCrypto/blake2
     - IrohaCrypto/Common
   - Kingfisher (6.3.0)
@@ -112,7 +116,7 @@ PODS:
 DEPENDENCIES:
   - CommonWallet/Core (from `https://github.com/soramitsu/Capital-iOS.git`, commit `33c7eec1db947eeae8e3b7feb217c60199599bd7`)
   - Cuckoo
-  - FearlessUtils (from `https://github.com/soramitsu/fearless-utils-iOS.git`, commit `08bf127ebcda8821541c961e756e8f95b15166af`)
+  - FearlessUtils (~> 0.11.0)
   - FireMock
   - Kingfisher
   - R.swift
@@ -135,6 +139,7 @@ SPEC REPOS:
     - BigInt
     - CocoaLumberjack
     - Cuckoo
+    - FearlessUtils
     - FireMock
     - IrohaCrypto
     - Kingfisher
@@ -160,9 +165,6 @@ EXTERNAL SOURCES:
   CommonWallet:
     :commit: 33c7eec1db947eeae8e3b7feb217c60199599bd7
     :git: https://github.com/soramitsu/Capital-iOS.git
-  FearlessUtils:
-    :commit: 08bf127ebcda8821541c961e756e8f95b15166af
-    :git: https://github.com/soramitsu/fearless-utils-iOS.git
   Starscream:
     :branch: feature/without-origin
     :git: https://github.com/ERussel/Starscream.git
@@ -174,9 +176,6 @@ CHECKOUT OPTIONS:
   CommonWallet:
     :commit: 33c7eec1db947eeae8e3b7feb217c60199599bd7
     :git: https://github.com/soramitsu/Capital-iOS.git
-  FearlessUtils:
-    :commit: 08bf127ebcda8821541c961e756e8f95b15166af
-    :git: https://github.com/soramitsu/fearless-utils-iOS.git
   Starscream:
     :commit: b9e69390d96e71427463469f47cdafb8c0db1b21
     :git: https://github.com/ERussel/Starscream.git
@@ -189,9 +188,9 @@ SPEC CHECKSUMS:
   CocoaLumberjack: b7e05132ff94f6ae4dfa9d5bce9141893a21d9da
   CommonWallet: 216009b2274247ec0a7f80b57f1f4d1ffbdd0a72
   Cuckoo: 09ff1b7c6613b9c27dafea90702ca32208fe59d3
-  FearlessUtils: 03891c4f0a4031ec8380fd336bc6b366992a4135
+  FearlessUtils: 9a5933f8b1a519bfc6baf21d6d23a2be92d638aa
   FireMock: 3eed872059c12f94855413347da83b9d6d1a6fac
-  IrohaCrypto: 753b4f9c2af9ddb97538e6b919d087f87112e708
+  IrohaCrypto: bef5e0fdbbfe587657d5de9a8961d7cb1f995a7e
   Kingfisher: 6c3df386db71d82c0817a429d2c9421a77396529
   R.swift: c533450b0f7dc494e0993f5f1a1db925d84c3006
   R.swift.Library: 0fc583cb55a99e28901299cc451614cad1161962
@@ -213,6 +212,6 @@ SPEC CHECKSUMS:
   TweetNacl: 3abf4d1d2082b0114e7a67410e300892448951e6
   xxHash-Swift: 30bd6a7507b3b7348a277c49b1cb6346c2905ec7
 
-PODFILE CHECKSUM: 988c3ff7a01e9dda01f577f881a28c5f561c6da5
+PODFILE CHECKSUM: fca4f18cad8f2e27e0224e4dc187cfc65d580580
 
 COCOAPODS: 1.10.1

--- a/fearless.xcodeproj/project.pbxproj
+++ b/fearless.xcodeproj/project.pbxproj
@@ -910,6 +910,7 @@
 		84DA3B1424C6D7C700B5E27F /* RuntimeDispatchInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84DA3B1324C6D7C700B5E27F /* RuntimeDispatchInfo.swift */; };
 		84DA3B1624C81ECE00B5E27F /* AccountItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84DA3B1524C81ECE00B5E27F /* AccountItem.swift */; };
 		84DA3B1924C8200E00B5E27F /* ConnectionItem+Default.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84DA3B1824C8200E00B5E27F /* ConnectionItem+Default.swift */; };
+		84DAC198268D3DD9002D0DF4 /* SNAddressType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84DAC197268D3DD9002D0DF4 /* SNAddressType.swift */; };
 		84DB4E1E25E93B1700A6DF41 /* Identity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84DB4E1D25E93B1700A6DF41 /* Identity.swift */; };
 		84DB4E2325E945E000A6DF41 /* SlashingSpans.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84DB4E2225E945E000A6DF41 /* SlashingSpans.swift */; };
 		84DB4E5C25EA71C100A6DF41 /* StringScaleMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84DB4E5B25EA71C100A6DF41 /* StringScaleMapper.swift */; };
@@ -2300,6 +2301,7 @@
 		84DA3B1324C6D7C700B5E27F /* RuntimeDispatchInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeDispatchInfo.swift; sourceTree = "<group>"; };
 		84DA3B1524C81ECE00B5E27F /* AccountItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountItem.swift; sourceTree = "<group>"; };
 		84DA3B1824C8200E00B5E27F /* ConnectionItem+Default.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConnectionItem+Default.swift"; sourceTree = "<group>"; };
+		84DAC197268D3DD9002D0DF4 /* SNAddressType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SNAddressType.swift; sourceTree = "<group>"; };
 		84DB4E1D25E93B1700A6DF41 /* Identity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Identity.swift; sourceTree = "<group>"; };
 		84DB4E2225E945E000A6DF41 /* SlashingSpans.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashingSpans.swift; sourceTree = "<group>"; };
 		84DB4E5B25EA71C100A6DF41 /* StringScaleMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringScaleMapper.swift; sourceTree = "<group>"; };
@@ -4709,6 +4711,7 @@
 		849013E024A9287F008F705E /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				84DAC197268D3DD9002D0DF4 /* SNAddressType.swift */,
 				8424A8C6262EC0E50091BFB1 /* PayoutInfo.swift */,
 				842876B024AE059700D91AD8 /* AboutData.swift */,
 				84113B6B255B2835009BD21A /* AccountCreateError.swift */,
@@ -8239,6 +8242,7 @@
 				84969734251CE9CD00C39524 /* ContactsConfigurator.swift in Sources */,
 				F458D3982642911B0055CB75 /* ControllerAccountViewModel.swift in Sources */,
 				73056D4920BE0E60FAF5073D /* AccountInfoInteractor.swift in Sources */,
+				84DAC198268D3DD9002D0DF4 /* SNAddressType.swift in Sources */,
 				63E857FD66F8DD99D4BB1665 /* AccountInfoViewController.swift in Sources */,
 				847C965425536199002D288F /* ExportRestoreJsonProtocols.swift in Sources */,
 				8409C26A2522192B0049B5C8 /* WalletFearlessDefinition.swift in Sources */,

--- a/fearless/Common/Extension/FearlessUtils/SS58FactoryExtensions.swift
+++ b/fearless/Common/Extension/FearlessUtils/SS58FactoryExtensions.swift
@@ -5,6 +5,7 @@ enum SS58AddressFactoryError: Error {
     case unexpectedAddress
 }
 
+// Deprecated: better not to use this methods anymore, will be removed when we get rid of SNAddressType
 extension SS58AddressFactoryProtocol {
     func extractAddressType(from address: String) throws -> SNAddressType {
         let addressTypeValue = try type(fromAddress: address)

--- a/fearless/Common/Extension/FearlessUtils/SS58FactoryExtensions.swift
+++ b/fearless/Common/Extension/FearlessUtils/SS58FactoryExtensions.swift
@@ -16,13 +16,20 @@ extension SS58AddressFactoryProtocol {
         return addressType
     }
 
-    func accountId(from address: String) throws -> Data {
+    func accountId(from address: String) throws -> AccountId {
         let addressType = try extractAddressType(from: address)
         return try accountId(fromAddress: address, type: addressType)
     }
 
-    func addressFromAccountId(data: Data, type: SNAddressType) throws -> String {
-        let accountId = try AccountIdWrapper(rawData: data)
-        return try address(fromPublicKey: accountId, type: type)
+    func accountId(fromAddress: AccountAddress, type: SNAddressType) throws -> AccountId {
+        try accountId(fromAddress: fromAddress, type: UInt16(type.rawValue))
+    }
+
+    func addressFromAccountId(data: AccountId, type: SNAddressType) throws -> AccountAddress {
+        try address(fromAccountId: data, type: UInt16(type.rawValue))
+    }
+
+    func address(fromPublicKey: IRPublicKeyProtocol, type: SNAddressType) throws -> AccountAddress {
+        try address(fromAccountId: fromPublicKey.rawData(), type: UInt16(type.rawValue))
     }
 }

--- a/fearless/Common/Model/SNAddressType.swift
+++ b/fearless/Common/Model/SNAddressType.swift
@@ -1,0 +1,10 @@
+import Foundation
+import FearlessUtils
+
+enum SNAddressType: UInt8 {
+    case polkadotMain = 0
+    case polkadotSecondary = 1
+    case kusamaMain = 2
+    case kusamaSecondary = 3
+    case genericSubstrate = 42
+}

--- a/fearless/Common/Services/WebSocketService/StorageSubscription/CommonStakingSubscription.swift
+++ b/fearless/Common/Services/WebSocketService/StorageSubscription/CommonStakingSubscription.swift
@@ -41,6 +41,8 @@ final class CommonStakingSubscription: WebSocketSubscribing {
     private func resolveSubscription() {
         let coderFactoryOperation = runtimeService.fetchCoderFactoryOperation()
 
+        logger?.debug("Will start resolving subscriptions")
+
         let remoteKeyOperation = ClosureOperation<[Data]> {
             let metadata = try coderFactoryOperation.extractNoCancellableResultData().metadata
 

--- a/fearless/Common/Services/WebSocketService/WebSocketService.swift
+++ b/fearless/Common/Services/WebSocketService/WebSocketService.swift
@@ -14,7 +14,11 @@ final class WebSocketService: WebSocketServiceProtocol {
             address: address
         )
         let storageFacade = SubstrateDataStorageFacade.shared
-        let subscriptionFactory = WebSocketSubscriptionFactory(storageFacade: storageFacade)
+        let subscriptionFactory = WebSocketSubscriptionFactory(
+            storageFacade: storageFacade,
+            runtimeService: RuntimeRegistryFacade.sharedService,
+            operationManager: OperationManagerFacade.sharedManager
+        )
         return WebSocketService(
             settings: settings,
             connectionFactory: WebSocketEngineFactory(),

--- a/fearless/Common/Services/WebSocketService/WebSocketSubscriptionFactory.swift
+++ b/fearless/Common/Services/WebSocketService/WebSocketSubscriptionFactory.swift
@@ -8,15 +8,21 @@ final class WebSocketSubscriptionFactory: WebSocketSubscriptionFactoryProtocol {
 
     let storageKeyFactory = StorageKeyFactory()
     let addressFactory = SS58AddressFactory()
-    let operationManager = OperationManagerFacade.sharedManager
+    let operationManager: OperationManagerProtocol
     let eventCenter = EventCenter.shared
     let logger = Logger.shared
 
-    let runtimeService = RuntimeRegistryFacade.sharedService
+    let runtimeService: RuntimeCodingServiceProtocol
     let providerFactory: SubstrateDataProviderFactoryProtocol
 
-    init(storageFacade: StorageFacadeProtocol) {
+    init(
+        storageFacade: StorageFacadeProtocol,
+        runtimeService: RuntimeCodingServiceProtocol,
+        operationManager: OperationManagerProtocol
+    ) {
         self.storageFacade = storageFacade
+        self.runtimeService = runtimeService
+        self.operationManager = operationManager
 
         providerFactory = SubstrateDataProviderFactory(
             facade: storageFacade,

--- a/fearless/Modules/AccountImport/Model/AccountImportJsonFactory.swift
+++ b/fearless/Modules/AccountImport/Model/AccountImportJsonFactory.swift
@@ -19,7 +19,12 @@ final class AccountImportJsonFactory {
             chain = genesisBasedChain
             networkTypeConfirmed = true
         } else {
-            chain = info.addressType?.chain
+            if let chainType = info.chainType {
+                chain = SNAddressType(rawValue: UInt8(chainType))?.chain
+            } else {
+                chain = nil
+            }
+
             networkTypeConfirmed = false
         }
 

--- a/fearless/Modules/Staking/YourValidators/View/YourValidatorTableCell.swift
+++ b/fearless/Modules/Staking/YourValidators/View/YourValidatorTableCell.swift
@@ -57,6 +57,7 @@ class YourValidatorTableCell: UITableViewCell {
         )
         stackView.isLayoutMarginsRelativeArrangement = true
         stackView.axis = .horizontal
+        stackView.alignment = .center
         stackView.spacing = 12
         return stackView
     }()

--- a/fearless/Modules/Staking/YourValidators/YourValidatorsInteractor.swift
+++ b/fearless/Modules/Staking/YourValidators/YourValidatorsInteractor.swift
@@ -99,8 +99,8 @@ final class YourValidatorsInteractor {
 
         let validatorsWrapper = createValidatorsWrapper(
             for: nomination,
-            stashAddress: stashAddress, activeEra: activeEra,
-            validatorInfoFactory: validatorOperationFactory
+            stashAddress: stashAddress,
+            activeEra: activeEra
         )
 
         validatorsWrapper.targetOperation.completionBlock = { [weak self] in
@@ -120,8 +120,7 @@ final class YourValidatorsInteractor {
     func createValidatorsWrapper(
         for nomination: Nomination,
         stashAddress: AccountAddress,
-        activeEra: EraIndex,
-        validatorInfoFactory _: ValidatorOperationFactoryProtocol
+        activeEra: EraIndex
     ) -> CompoundOperationWrapper<YourValidatorsModel> {
         if nomination.submittedIn >= activeEra {
             let activeValidatorsWrapper = validatorOperationFactory.activeValidatorsOperation(

--- a/fearless/Modules/Staking/YourValidators/YourValidatorsProtocols.swift
+++ b/fearless/Modules/Staking/YourValidators/YourValidatorsProtocols.swift
@@ -1,6 +1,6 @@
 import SoraFoundation
 
-protocol YourValidatorsViewProtocol: ControllerBackedProtocol, Localizable {
+protocol YourValidatorsViewProtocol: ControllerBackedProtocol, Localizable, LoadableViewProtocol {
     func reload(state: YourValidatorsViewState)
 }
 

--- a/fearless/Modules/Staking/YourValidators/YourValidatorsViewController.swift
+++ b/fearless/Modules/Staking/YourValidators/YourValidatorsViewController.swift
@@ -196,6 +196,12 @@ extension YourValidatorsViewController: YourValidatorsViewProtocol {
     func reload(state: YourValidatorsViewState) {
         viewState = state
 
+        if case .loading = viewState {
+            didStartLoading()
+        } else {
+            didStopLoading()
+        }
+
         rootView.tableView.reloadData()
         reloadEmptyState(animated: true)
     }

--- a/fearless/Modules/Wallet/WalletQRCoderFactory.swift
+++ b/fearless/Modules/Wallet/WalletQRCoderFactory.swift
@@ -40,7 +40,7 @@ final class WalletQRDecoder: WalletQRDecoderProtocol {
     private let assets: [WalletAsset]
 
     init(networkType: SNAddressType, assets: [WalletAsset]) {
-        substrateDecoder = SubstrateQRDecoder(networkType: networkType)
+        substrateDecoder = SubstrateQRDecoder(chainType: ChainType(networkType.rawValue))
         self.assets = assets
     }
 
@@ -49,7 +49,7 @@ final class WalletQRDecoder: WalletQRDecoderProtocol {
 
         let accountId = try addressFactory.accountId(
             fromAddress: info.address,
-            type: substrateDecoder.networkType
+            type: substrateDecoder.chainType
         )
 
         return ReceiveInfo(

--- a/fearlessIntegrationTests/CalculatorServiceTests.swift
+++ b/fearlessIntegrationTests/CalculatorServiceTests.swift
@@ -71,40 +71,11 @@ class CalculatorServiceTests: XCTestCase {
     }
 
     func testDecodeLocalEncodedValidatorsForWestend() {
-        performTestFetchingLocalEncodedValidators(for: .westend)
+        performTestDecodeLocalEncodedValidators(for: .westend)
     }
 
     func testDecodeLocalEncodedValidatorsForKusama() {
-        do {
-            let storageFacade = SubstrateDataStorageFacade.shared
-            let chain = Chain.kusama
-
-            let codingFactory = try fetchCoderFactory(for: chain, storageFacade: storageFacade)
-
-            guard let era = try fetchActiveEra(for: chain,
-                                               storageFacade: storageFacade,
-                                               codingFactory: codingFactory) else {
-                XCTFail("No era found")
-                return
-            }
-
-            let items = try fetchLocalEncodedValidators(for: chain,
-                                                        era: era,
-                                                        coderFactory: codingFactory,
-                                                        storageFacade: storageFacade)
-            XCTAssert(!items.isEmpty)
-
-            measure {
-                do {
-                    let decodedValidators = try decodeEncodedValidators(items, codingFactory: codingFactory)
-                    XCTAssertEqual(decodedValidators.count, items.count)
-                } catch {
-                    XCTFail("Unexpected error \(error)")
-                }
-            }
-        } catch {
-            XCTFail("Unexpected error: \(error)")
-        }
+        performTestDecodeLocalEncodedValidators(for: .kusama)
     }
 
     func testFetchingLocalEncodedValidatorsForKusama() {
@@ -593,7 +564,7 @@ class CalculatorServiceTests: XCTestCase {
         return try erasStakersKeyOperation.extractNoCancellableResultData().first
     }
 
-    private func performTestFetchingLocalEncodedValidators(for chain: Chain) {
+    private func performTestDecodeLocalEncodedValidators(for chain: Chain) {
         do {
             let storageFacade = SubstrateDataStorageFacade.shared
 
@@ -606,13 +577,16 @@ class CalculatorServiceTests: XCTestCase {
                 return
             }
 
+            let items = try fetchLocalEncodedValidators(for: chain,
+                                                        era: era,
+                                                        coderFactory: codingFactory,
+                                                        storageFacade: storageFacade)
+            XCTAssert(!items.isEmpty)
+
             measure {
                 do {
-                    let items = try fetchLocalEncodedValidators(for: chain,
-                                                                era: era,
-                                                                coderFactory: codingFactory,
-                                                                storageFacade: storageFacade)
-                    XCTAssert(!items.isEmpty)
+                    let decodedValidators = try decodeEncodedValidators(items, codingFactory: codingFactory)
+                    XCTAssertEqual(decodedValidators.count, items.count)
                 } catch {
                     XCTFail("Unexpected error \(error)")
                 }

--- a/fearlessTests/Mocks/ModuleMocks.swift
+++ b/fearlessTests/Mocks/ModuleMocks.swift
@@ -42653,6 +42653,34 @@ import SoraFoundation
         
     }
     
+    
+    
+     var loadableContentView: UIView! {
+        get {
+            return cuckoo_manager.getter("loadableContentView",
+                superclassCall:
+                    
+                    Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                    ,
+                defaultCall: __defaultImplStub!.loadableContentView)
+        }
+        
+    }
+    
+    
+    
+     var shouldDisableInteractionWhenLoading: Bool {
+        get {
+            return cuckoo_manager.getter("shouldDisableInteractionWhenLoading",
+                superclassCall:
+                    
+                    Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                    ,
+                defaultCall: __defaultImplStub!.shouldDisableInteractionWhenLoading)
+        }
+        
+    }
+    
 
     
 
@@ -42687,6 +42715,36 @@ import SoraFoundation
         
     }
     
+    
+    
+     func didStartLoading()  {
+        
+    return cuckoo_manager.call("didStartLoading()",
+            parameters: (),
+            escapingParameters: (),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.didStartLoading())
+        
+    }
+    
+    
+    
+     func didStopLoading()  {
+        
+    return cuckoo_manager.call("didStopLoading()",
+            parameters: (),
+            escapingParameters: (),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.didStopLoading())
+        
+    }
+    
 
 	 struct __StubbingProxy_YourValidatorsViewProtocol: Cuckoo.StubbingProxy {
 	    private let cuckoo_manager: Cuckoo.MockManager
@@ -42711,6 +42769,16 @@ import SoraFoundation
 	    }
 	    
 	    
+	    var loadableContentView: Cuckoo.ProtocolToBeStubbedReadOnlyProperty<MockYourValidatorsViewProtocol, UIView?> {
+	        return .init(manager: cuckoo_manager, name: "loadableContentView")
+	    }
+	    
+	    
+	    var shouldDisableInteractionWhenLoading: Cuckoo.ProtocolToBeStubbedReadOnlyProperty<MockYourValidatorsViewProtocol, Bool> {
+	        return .init(manager: cuckoo_manager, name: "shouldDisableInteractionWhenLoading")
+	    }
+	    
+	    
 	    func reload<M1: Cuckoo.Matchable>(state: M1) -> Cuckoo.ProtocolStubNoReturnFunction<(YourValidatorsViewState)> where M1.MatchedType == YourValidatorsViewState {
 	        let matchers: [Cuckoo.ParameterMatcher<(YourValidatorsViewState)>] = [wrap(matchable: state) { $0 }]
 	        return .init(stub: cuckoo_manager.createStub(for: MockYourValidatorsViewProtocol.self, method: "reload(state: YourValidatorsViewState)", parameterMatchers: matchers))
@@ -42719,6 +42787,16 @@ import SoraFoundation
 	    func applyLocalization() -> Cuckoo.ProtocolStubNoReturnFunction<()> {
 	        let matchers: [Cuckoo.ParameterMatcher<Void>] = []
 	        return .init(stub: cuckoo_manager.createStub(for: MockYourValidatorsViewProtocol.self, method: "applyLocalization()", parameterMatchers: matchers))
+	    }
+	    
+	    func didStartLoading() -> Cuckoo.ProtocolStubNoReturnFunction<()> {
+	        let matchers: [Cuckoo.ParameterMatcher<Void>] = []
+	        return .init(stub: cuckoo_manager.createStub(for: MockYourValidatorsViewProtocol.self, method: "didStartLoading()", parameterMatchers: matchers))
+	    }
+	    
+	    func didStopLoading() -> Cuckoo.ProtocolStubNoReturnFunction<()> {
+	        let matchers: [Cuckoo.ParameterMatcher<Void>] = []
+	        return .init(stub: cuckoo_manager.createStub(for: MockYourValidatorsViewProtocol.self, method: "didStopLoading()", parameterMatchers: matchers))
 	    }
 	    
 	}
@@ -42750,6 +42828,16 @@ import SoraFoundation
 	        return .init(manager: cuckoo_manager, name: "localizationManager", callMatcher: callMatcher, sourceLocation: sourceLocation)
 	    }
 	    
+	    
+	    var loadableContentView: Cuckoo.VerifyReadOnlyProperty<UIView?> {
+	        return .init(manager: cuckoo_manager, name: "loadableContentView", callMatcher: callMatcher, sourceLocation: sourceLocation)
+	    }
+	    
+	    
+	    var shouldDisableInteractionWhenLoading: Cuckoo.VerifyReadOnlyProperty<Bool> {
+	        return .init(manager: cuckoo_manager, name: "shouldDisableInteractionWhenLoading", callMatcher: callMatcher, sourceLocation: sourceLocation)
+	    }
+	    
 	
 	    
 	    @discardableResult
@@ -42762,6 +42850,18 @@ import SoraFoundation
 	    func applyLocalization() -> Cuckoo.__DoNotUse<(), Void> {
 	        let matchers: [Cuckoo.ParameterMatcher<Void>] = []
 	        return cuckoo_manager.verify("applyLocalization()", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+	    }
+	    
+	    @discardableResult
+	    func didStartLoading() -> Cuckoo.__DoNotUse<(), Void> {
+	        let matchers: [Cuckoo.ParameterMatcher<Void>] = []
+	        return cuckoo_manager.verify("didStartLoading()", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+	    }
+	    
+	    @discardableResult
+	    func didStopLoading() -> Cuckoo.__DoNotUse<(), Void> {
+	        let matchers: [Cuckoo.ParameterMatcher<Void>] = []
+	        return cuckoo_manager.verify("didStopLoading()", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
 	    }
 	    
 	}
@@ -42795,6 +42895,22 @@ import SoraFoundation
         
     }
     
+    
+     var loadableContentView: UIView! {
+        get {
+            return DefaultValueRegistry.defaultValue(for: (UIView?).self)
+        }
+        
+    }
+    
+    
+     var shouldDisableInteractionWhenLoading: Bool {
+        get {
+            return DefaultValueRegistry.defaultValue(for: (Bool).self)
+        }
+        
+    }
+    
 
     
 
@@ -42804,6 +42920,14 @@ import SoraFoundation
     }
     
     public func applyLocalization()   {
+        return DefaultValueRegistry.defaultValue(for: (Void).self)
+    }
+    
+     func didStartLoading()   {
+        return DefaultValueRegistry.defaultValue(for: (Void).self)
+    }
+    
+     func didStopLoading()   {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
     


### PR DESCRIPTION
- improve slow implementation of hex coding and update the crypto library that should speedup  parsing of elected validators
- add spinner to your validators screen