### PR TITLE
FLW-454 Not updated available balance when confirmed transaction

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Capital-iOS"]
+	path = Capital-iOS
+	url = https://github.com/soramitsu/Capital-iOS.git

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,5 +1,6 @@
 excluded:
   - Pods
+  - Capital-iOS
   - PrivatePods
   - R.generated.swift
   - fearlessTests

--- a/Podfile
+++ b/Podfile
@@ -9,7 +9,7 @@ abstract_target 'fearlessAll' do
   pod 'SoraKeystore'
   pod 'SoraUI', '~> 1.10.1'
   pod 'RobinHood', '~> 2.6.0'
-  pod 'CommonWallet/Core', :git => 'https://github.com/soramitsu/Capital-iOS.git', :commit => '33c7eec1db947eeae8e3b7feb217c60199599bd7'
+  pod 'CommonWallet/Core', :path => './Capital-iOS'
   pod 'SoraFoundation', '~> 0.10.0'
   pod 'SwiftyBeaver'
   pod 'Starscream', :git => 'https://github.com/ERussel/Starscream.git', :branch => 'feature/without-origin'
@@ -31,7 +31,7 @@ abstract_target 'fearlessAll' do
     pod 'FireMock', :inhibit_warnings => true
     pod 'SoraKeystore'
     pod 'RobinHood', '~> 2.6.0'
-    pod 'CommonWallet/Core', :git => 'https://github.com/soramitsu/Capital-iOS.git', :commit => '33c7eec1db947eeae8e3b7feb217c60199599bd7'
+    pod 'CommonWallet/Core', :path => './Capital-iOS'
     pod 'Sourcery', '~> 1.4'
 
   end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -114,7 +114,7 @@ PODS:
   - xxHash-Swift (1.0.13)
 
 DEPENDENCIES:
-  - CommonWallet/Core (from `https://github.com/soramitsu/Capital-iOS.git`, commit `33c7eec1db947eeae8e3b7feb217c60199599bd7`)
+  - CommonWallet/Core (from `./Capital-iOS`)
   - Cuckoo
   - FearlessUtils (~> 0.11.0)
   - FireMock
@@ -163,8 +163,7 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   CommonWallet:
-    :commit: 33c7eec1db947eeae8e3b7feb217c60199599bd7
-    :git: https://github.com/soramitsu/Capital-iOS.git
+    :path: "./Capital-iOS"
   Starscream:
     :branch: feature/without-origin
     :git: https://github.com/ERussel/Starscream.git
@@ -173,9 +172,6 @@ EXTERNAL SOURCES:
     :tag: 3.0.0
 
 CHECKOUT OPTIONS:
-  CommonWallet:
-    :commit: 33c7eec1db947eeae8e3b7feb217c60199599bd7
-    :git: https://github.com/soramitsu/Capital-iOS.git
   Starscream:
     :commit: b9e69390d96e71427463469f47cdafb8c0db1b21
     :git: https://github.com/ERussel/Starscream.git
@@ -212,6 +208,6 @@ SPEC CHECKSUMS:
   TweetNacl: 3abf4d1d2082b0114e7a67410e300892448951e6
   xxHash-Swift: 30bd6a7507b3b7348a277c49b1cb6346c2905ec7
 
-PODFILE CHECKSUM: fca4f18cad8f2e27e0224e4dc187cfc65d580580
+PODFILE CHECKSUM: 01badf56fd015f41c6ee7b72a9bb47e621c2327d
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
Move to `git submodules` instead of pulling pod by commit hash. 
```
cd /fearless
git submodule update
pod install
open Xcode workspace
navigate to Pods/Development pods/CommonWallet
...
profit!
```