### PR TITLE
Fix double slash for subscan url

### DIFF
--- a/fearless/Common/Network/Subscan/SubscanDefinitions.swift
+++ b/fearless/Common/Network/Subscan/SubscanDefinitions.swift
@@ -5,7 +5,7 @@ struct SubscanApi {
     static let price = "api/open/price"
     static let transfers = "api/scan/transfers"
     static let rewardsAndSlashes = "api/scan/account/reward_slash"
-    static let extrinsics = "/api/scan/extrinsics"
+    static let extrinsics = "api/scan/extrinsics"
 }
 
 extension WalletAssetId {


### PR DESCRIPTION
Fix double slash in SubscanDefinitions file

Signed-off-by: Stepan Lavrentev <lawrentievsv@gmail.com>