### PR TITLE
Runtime sync

### DIFF
--- a/fearless.xcodeproj/project.pbxproj
+++ b/fearless.xcodeproj/project.pbxproj
@@ -818,6 +818,7 @@
 		84A6171B2625AC3E007B75E1 /* CallCodingPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A6171A2625AC3E007B75E1 /* CallCodingPath.swift */; };
 		84A617262625AF51007B75E1 /* RuntimeMetadata+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A617252625AF51007B75E1 /* RuntimeMetadata+Internal.swift */; };
 		84A8FD8E265FDA76002ADB58 /* CrowdloanContributionConfirmData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A8FD8D265FDA76002ADB58 /* CrowdloanContributionConfirmData.swift */; };
+		84AA004326C5DFD800BCB4DC /* RuntimeSyncServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84AA004226C5DFD800BCB4DC /* RuntimeSyncServiceTests.swift */; };
 		84ACEBF2261E664900AAE665 /* WalletHistoryFilterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84ACEBF1261E664900AAE665 /* WalletHistoryFilterViewModel.swift */; };
 		84ACEBFA261E684A00AAE665 /* WalletHistoryFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84ACEBF9261E684A00AAE665 /* WalletHistoryFilter.swift */; };
 		84ACEBFF261E6C7C00AAE665 /* WalletHistoryFilterViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84ACEBFE261E6C7C00AAE665 /* WalletHistoryFilterViewLayout.swift */; };
@@ -2293,6 +2294,7 @@
 		84A6171A2625AC3E007B75E1 /* CallCodingPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallCodingPath.swift; sourceTree = "<group>"; };
 		84A617252625AF51007B75E1 /* RuntimeMetadata+Internal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RuntimeMetadata+Internal.swift"; sourceTree = "<group>"; };
 		84A8FD8D265FDA76002ADB58 /* CrowdloanContributionConfirmData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrowdloanContributionConfirmData.swift; sourceTree = "<group>"; };
+		84AA004226C5DFD800BCB4DC /* RuntimeSyncServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeSyncServiceTests.swift; sourceTree = "<group>"; };
 		84ACEBF1261E664900AAE665 /* WalletHistoryFilterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletHistoryFilterViewModel.swift; sourceTree = "<group>"; };
 		84ACEBF9261E684A00AAE665 /* WalletHistoryFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletHistoryFilter.swift; sourceTree = "<group>"; };
 		84ACEBFE261E6C7C00AAE665 /* WalletHistoryFilterViewLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletHistoryFilterViewLayout.swift; sourceTree = "<group>"; };
@@ -3890,6 +3892,7 @@
 				84443B9F26C121BA00C33B5D /* MockConnection.swift */,
 				84443BA326C13D6900C33B5D /* ChainModelGenerator.swift */,
 				840BF22426C2653100E3A955 /* ChainSyncServiceTests.swift */,
+				84AA004226C5DFD800BCB4DC /* RuntimeSyncServiceTests.swift */,
 			);
 			path = ChainRegistry;
 			sourceTree = "<group>";
@@ -7707,7 +7710,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "#! /bin/sh\n# Define output file. Change \"$PROJECT_DIR/${PROJECT_NAME}Tests\" to your test's root source folder, if it's not the default name.\nOUTPUT_FILE=\"${PROJECT_NAME}Tests/Mocks/CommonMocks.swift\"\necho \"Generated Mocks File = $OUTPUT_FILE\"\n\n# Define input directory. Change \"${PROJECT_DIR}/${PROJECT_NAME}\" to your project's root source folder, if it's not the default name.\nINPUT_DIR=\"${PROJECT_NAME}\"\necho \"Mocks Input Directory = $INPUT_DIR\"\n\n# Generate mock files, include as many input files as you'd like to create mocks for.\n\"Pods/Cuckoo/run\" generate --no-header --testable \"${PROJECT_NAME},SoraKeystore\" \\\n--exclude \"\" \\\n--output \"${OUTPUT_FILE}\" \\\n\"$INPUT_DIR/Common/Helpers/Scheduler.swift\" \\\n\"$INPUT_DIR/Common/LocalAuthentication/BiometryAuth.swift\" \\\n\"$INPUT_DIR/Common/EventCenter/EventProtocols.swift\" \\\n\"$INPUT_DIR/Common/Network/SubstrateOperationFactory.swift\" \\\n\"$INPUT_DIR/Common/Helpers/AccountRepositoryFactory.swift\" \\\n\"$INPUT_DIR/../Pods/SoraKeystore/SoraKeystore/Classes/Keychain/KeystoreProtocols.swift\"  \\\n\"$INPUT_DIR/Common/Network/JSONRPC/JSONRPCEngine.swift\" \\\n\"$INPUT_DIR/Common/Operation/EraCountdownOperationFactory/EraCountdownOperationFactory.swift\" \\\n\"$INPUT_DIR/Common/Network/JSONRPC/ConnectionAutobalancing.swift\" \\\n\"$INPUT_DIR/Common/Network/JSONRPC/ConnectionStateReporting.swift\" \\\n\"$INPUT_DIR/Common/Services/ChainRegistry/ConnectionPool/ConnectionFactory.swift\" \\\n\"$INPUT_DIR/Common/Network/DataOperationFactory.swift\" \\\n";
+			shellScript = "#! /bin/sh\n# Define output file. Change \"$PROJECT_DIR/${PROJECT_NAME}Tests\" to your test's root source folder, if it's not the default name.\nOUTPUT_FILE=\"${PROJECT_NAME}Tests/Mocks/CommonMocks.swift\"\necho \"Generated Mocks File = $OUTPUT_FILE\"\n\n# Define input directory. Change \"${PROJECT_DIR}/${PROJECT_NAME}\" to your project's root source folder, if it's not the default name.\nINPUT_DIR=\"${PROJECT_NAME}\"\necho \"Mocks Input Directory = $INPUT_DIR\"\n\n# Generate mock files, include as many input files as you'd like to create mocks for.\n\"Pods/Cuckoo/run\" generate --no-header --testable \"${PROJECT_NAME},SoraKeystore\" \\\n--exclude \"\" \\\n--output \"${OUTPUT_FILE}\" \\\n\"$INPUT_DIR/Common/Helpers/Scheduler.swift\" \\\n\"$INPUT_DIR/Common/LocalAuthentication/BiometryAuth.swift\" \\\n\"$INPUT_DIR/Common/EventCenter/EventProtocols.swift\" \\\n\"$INPUT_DIR/Common/Network/SubstrateOperationFactory.swift\" \\\n\"$INPUT_DIR/Common/Helpers/AccountRepositoryFactory.swift\" \\\n\"$INPUT_DIR/../Pods/SoraKeystore/SoraKeystore/Classes/Keychain/KeystoreProtocols.swift\"  \\\n\"$INPUT_DIR/Common/Network/JSONRPC/JSONRPCEngine.swift\" \\\n\"$INPUT_DIR/Common/Operation/EraCountdownOperationFactory/EraCountdownOperationFactory.swift\" \\\n\"$INPUT_DIR/Common/Network/JSONRPC/ConnectionAutobalancing.swift\" \\\n\"$INPUT_DIR/Common/Network/JSONRPC/ConnectionStateReporting.swift\" \\\n\"$INPUT_DIR/Common/Services/ChainRegistry/ConnectionPool/ConnectionFactory.swift\" \\\n\"$INPUT_DIR/Common/Network/DataOperationFactory.swift\" \\\n\"$INPUT_DIR/Common/Services/ChainRegistry/RuntimeFilesOperationFactory.swift\" \\\n";
 		};
 		849013CD24A92260008F705E /* Swiftlint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -9173,6 +9176,7 @@
 				DCDAE9E8C805B71A8F8CEFBD /* YourValidatorListTests.swift in Sources */,
 				70EAB410A0106F22C2183847 /* StakingUnbondSetupTests.swift in Sources */,
 				33D41E7EAA441A589449CD4E /* StakingUnbondConfirmTests.swift in Sources */,
+				84AA004326C5DFD800BCB4DC /* RuntimeSyncServiceTests.swift in Sources */,
 				C4427244A22EA7BA7F7C9E9F /* StakingRedeemTests.swift in Sources */,
 				7365B203D7F32028225366E5 /* ControllerAccountTests.swift in Sources */,
 				48A787921C2B3E9F22722154 /* ControllerAccountConfirmationTests.swift in Sources */,

--- a/fearless.xcodeproj/project.pbxproj
+++ b/fearless.xcodeproj/project.pbxproj
@@ -799,6 +799,7 @@
 		849DEBDC25ED134A00C64C19 /* SelectValidatorsConfirmViewModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849DEBDB25ED134A00C64C19 /* SelectValidatorsConfirmViewModelFactory.swift */; };
 		849DEC5925ED756F00C64C19 /* SubstrateCallFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849DEC5825ED756F00C64C19 /* SubstrateCallFactory.swift */; };
 		849DEC6125EE13CE00C64C19 /* AddressOptionsPresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849DEC6025EE13CE00C64C19 /* AddressOptionsPresentable.swift */; };
+		849DF02D26C40B7900B702F4 /* RuntimeFilesOperationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849DF02C26C40B7900B702F4 /* RuntimeFilesOperationFactory.swift */; };
 		849E0CD025CFDDB700B33506 /* StorageUpdateData+Decoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849E0CCF25CFDDB700B33506 /* StorageUpdateData+Decoding.swift */; };
 		849E2332254AEFB400B1F6D4 /* InvoiceScanConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849E2331254AEFB400B1F6D4 /* InvoiceScanConfigurator.swift */; };
 		849E2351254AF44200B1F6D4 /* InvoiceScanLocalSearchEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849E2350254AF44200B1F6D4 /* InvoiceScanLocalSearchEngine.swift */; };
@@ -2272,6 +2273,7 @@
 		849DEBDB25ED134A00C64C19 /* SelectValidatorsConfirmViewModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectValidatorsConfirmViewModelFactory.swift; sourceTree = "<group>"; };
 		849DEC5825ED756F00C64C19 /* SubstrateCallFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubstrateCallFactory.swift; sourceTree = "<group>"; };
 		849DEC6025EE13CE00C64C19 /* AddressOptionsPresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressOptionsPresentable.swift; sourceTree = "<group>"; };
+		849DF02C26C40B7900B702F4 /* RuntimeFilesOperationFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeFilesOperationFactory.swift; sourceTree = "<group>"; };
 		849E0CCF25CFDDB700B33506 /* StorageUpdateData+Decoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StorageUpdateData+Decoding.swift"; sourceTree = "<group>"; };
 		849E2331254AEFB400B1F6D4 /* InvoiceScanConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvoiceScanConfigurator.swift; sourceTree = "<group>"; };
 		849E2350254AF44200B1F6D4 /* InvoiceScanLocalSearchEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvoiceScanLocalSearchEngine.swift; sourceTree = "<group>"; };
@@ -5874,6 +5876,7 @@
 				84CA68D826BE9E7F003B9453 /* SpecVersionSubscription.swift */,
 				84CA68DA26BEA33F003B9453 /* ChainRegistryFactory.swift */,
 				84CA68E026BEAC7C003B9453 /* SpecVersionSubscriptionFactory.swift */,
+				849DF02C26C40B7900B702F4 /* RuntimeFilesOperationFactory.swift */,
 			);
 			path = ChainRegistry;
 			sourceTree = "<group>";
@@ -9018,6 +9021,7 @@
 				270C21973CB61F0BF3D2D1E3 /* CrowdloanListProtocols.swift in Sources */,
 				6D61E43A79BDF5EA6CA9E85D /* CrowdloanListWireframe.swift in Sources */,
 				A090FF206B56A0E465C62072 /* CrowdloanListPresenter.swift in Sources */,
+				849DF02D26C40B7900B702F4 /* RuntimeFilesOperationFactory.swift in Sources */,
 				0B2B9C6E2BA2E924D6A54F4B /* CrowdloanListInteractor.swift in Sources */,
 				C083E2FC291784BF60EE73BA /* CrowdloanListViewController.swift in Sources */,
 				5888936B3D13D92F1534E08B /* CrowdloanListViewLayout.swift in Sources */,

--- a/fearless.xcodeproj/project.pbxproj
+++ b/fearless.xcodeproj/project.pbxproj
@@ -800,6 +800,7 @@
 		849DEC5925ED756F00C64C19 /* SubstrateCallFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849DEC5825ED756F00C64C19 /* SubstrateCallFactory.swift */; };
 		849DEC6125EE13CE00C64C19 /* AddressOptionsPresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849DEC6025EE13CE00C64C19 /* AddressOptionsPresentable.swift */; };
 		849DF02D26C40B7900B702F4 /* RuntimeFilesOperationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849DF02C26C40B7900B702F4 /* RuntimeFilesOperationFactory.swift */; };
+		849DF02F26C53DB900B702F4 /* RuntimeSyncEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849DF02E26C53DB900B702F4 /* RuntimeSyncEvents.swift */; };
 		849E0CD025CFDDB700B33506 /* StorageUpdateData+Decoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849E0CCF25CFDDB700B33506 /* StorageUpdateData+Decoding.swift */; };
 		849E2332254AEFB400B1F6D4 /* InvoiceScanConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849E2331254AEFB400B1F6D4 /* InvoiceScanConfigurator.swift */; };
 		849E2351254AF44200B1F6D4 /* InvoiceScanLocalSearchEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849E2350254AF44200B1F6D4 /* InvoiceScanLocalSearchEngine.swift */; };
@@ -2274,6 +2275,7 @@
 		849DEC5825ED756F00C64C19 /* SubstrateCallFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubstrateCallFactory.swift; sourceTree = "<group>"; };
 		849DEC6025EE13CE00C64C19 /* AddressOptionsPresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressOptionsPresentable.swift; sourceTree = "<group>"; };
 		849DF02C26C40B7900B702F4 /* RuntimeFilesOperationFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeFilesOperationFactory.swift; sourceTree = "<group>"; };
+		849DF02E26C53DB900B702F4 /* RuntimeSyncEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeSyncEvents.swift; sourceTree = "<group>"; };
 		849E0CCF25CFDDB700B33506 /* StorageUpdateData+Decoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StorageUpdateData+Decoding.swift"; sourceTree = "<group>"; };
 		849E2331254AEFB400B1F6D4 /* InvoiceScanConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvoiceScanConfigurator.swift; sourceTree = "<group>"; };
 		849E2350254AF44200B1F6D4 /* InvoiceScanLocalSearchEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvoiceScanLocalSearchEngine.swift; sourceTree = "<group>"; };
@@ -4358,6 +4360,7 @@
 				8461CC8926BD2F07007460E4 /* RuntimeProviderPool.swift */,
 				84CA68D026BE99ED003B9453 /* RuntimeProviderFactory.swift */,
 				84CA68D226BE9A35003B9453 /* RuntimeProvider.swift */,
+				84CA68CE26BD6872003B9453 /* RuntimeSyncService.swift */,
 			);
 			path = RuntimeProviderPool;
 			sourceTree = "<group>";
@@ -5870,7 +5873,6 @@
 			children = (
 				8461CC8826BD2EE8007460E4 /* RuntimeProviderPool */,
 				84243B2926B9676500581AB7 /* ConnectionPool */,
-				84CA68CE26BD6872003B9453 /* RuntimeSyncService.swift */,
 				84CA68D426BE9E62003B9453 /* ChainRegistry.swift */,
 				84CA68D626BE9E6F003B9453 /* ChainSyncService.swift */,
 				84CA68D826BE9E7F003B9453 /* SpecVersionSubscription.swift */,
@@ -6146,6 +6148,7 @@
 				84F4386525D9B8C600AEDA56 /* TypeRegistryPrepared.swift */,
 				AE7129B3260872ED000AA3F5 /* EraStakersInfoChanged.swift */,
 				840BF22626C2C8A600E3A955 /* ChainSyncEvents.swift */,
+				849DF02E26C53DB900B702F4 /* RuntimeSyncEvents.swift */,
 			);
 			path = Events;
 			sourceTree = "<group>";
@@ -8174,6 +8177,7 @@
 				84754C9C2513B26000854599 /* AccountPickerTableViewCell.swift in Sources */,
 				8472C5B1265CF9C500E2481B /* StakingRewardDestConfirmViewFactory.swift in Sources */,
 				F4488CF226143E0000AEE6DB /* EraRewardPoints.swift in Sources */,
+				849DF02F26C53DB900B702F4 /* RuntimeSyncEvents.swift in Sources */,
 				84265E042523D20A005EEE2D /* WalletBaseAmountView.swift in Sources */,
 				84155DF12539DC0300A27058 /* WebSocketServiceProtocol.swift in Sources */,
 				844DD65525EAF32D00B1DA97 /* SelectValidatorsStartViewModel.swift in Sources */,

--- a/fearless/Common/EventCenter/EventVisitor.swift
+++ b/fearless/Common/EventCenter/EventVisitor.swift
@@ -14,6 +14,10 @@ protocol EventVisitorProtocol: AnyObject {
     func processChainSyncDidStart(event: ChainSyncDidStart)
     func processChainSyncDidComplete(event: ChainSyncDidComplete)
     func processChainSyncDidFail(event: ChainSyncDidFail)
+
+    func processRuntimeBaseTypesSyncCompleted(event: RuntimeBaseTypesSyncCompleted)
+    func processRuntimeChainTypesSyncCompleted(event: RuntimeChainTypesSyncCompleted)
+    func processRuntimeChainMetadataSyncCompleted(event: RuntimeMetadataSyncCompleted)
 }
 
 extension EventVisitorProtocol {
@@ -30,4 +34,8 @@ extension EventVisitorProtocol {
     func processChainSyncDidStart(event _: ChainSyncDidStart) {}
     func processChainSyncDidComplete(event _: ChainSyncDidComplete) {}
     func processChainSyncDidFail(event _: ChainSyncDidFail) {}
+
+    func processRuntimeBaseTypesSyncCompleted(event _: RuntimeBaseTypesSyncCompleted) {}
+    func processRuntimeChainTypesSyncCompleted(event _: RuntimeChainTypesSyncCompleted) {}
+    func processRuntimeChainMetadataSyncCompleted(event _: RuntimeMetadataSyncCompleted) {}
 }

--- a/fearless/Common/EventCenter/Events/RuntimeSyncEvents.swift
+++ b/fearless/Common/EventCenter/Events/RuntimeSyncEvents.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+struct RuntimeBaseTypesSyncCompleted: EventProtocol {
+    let fileHash: String
+
+    func accept(visitor: EventVisitorProtocol) {
+        visitor.processRuntimeBaseTypesSyncCompleted(event: self)
+    }
+}
+
+struct RuntimeChainTypesSyncCompleted: EventProtocol {
+    let chainId: ChainModel.Id
+    let fileHash: String
+
+    func accept(visitor: EventVisitorProtocol) {
+        visitor.processRuntimeChainTypesSyncCompleted(event: self)
+    }
+}
+
+struct RuntimeMetadataSyncCompleted: EventProtocol {
+    let chainId: ChainModel.Id
+    let version: RuntimeVersion
+
+    func accept(visitor: EventVisitorProtocol) {
+        visitor.processRuntimeChainMetadataSyncCompleted(event: self)
+    }
+}

--- a/fearless/Common/Model/ChainRegistry/ChainModel.swift
+++ b/fearless/Common/Model/ChainRegistry/ChainModel.swift
@@ -5,11 +5,16 @@ struct ChainModel: Codable, Hashable {
     // swiftlint:disable type_name
     typealias Id = String
 
+    struct TypesSettings: Codable, Hashable {
+        let url: URL
+        let overridesCommon: Bool
+    }
+
     let chainId: Id
     let assets: [AssetModel]
     let nodes: [ChainNodeModel]
     let addressPrefix: UInt16
-    let types: URL?
+    let types: TypesSettings?
     let icon: URL
     let isEthereumBased: Bool
 }

--- a/fearless/Common/Model/ChainRegistry/ChainModel.swift
+++ b/fearless/Common/Model/ChainRegistry/ChainModel.swift
@@ -9,7 +9,7 @@ struct ChainModel: Codable, Hashable {
     let assets: [AssetModel]
     let nodes: [ChainNodeModel]
     let addressPrefix: UInt16
-    let types: URL
+    let types: URL?
     let icon: URL
     let isEthereumBased: Bool
 }

--- a/fearless/Common/Model/ChainRegistry/ChainModelMapper.swift
+++ b/fearless/Common/Model/ChainRegistry/ChainModelMapper.swift
@@ -43,7 +43,7 @@ extension ChainModelMapper: CoreDataMapperProtocol {
             assets: assets,
             nodes: nodes,
             addressPrefix: UInt16(bitPattern: entity.addressPrefix),
-            types: entity.types!,
+            types: entity.types,
             icon: entity.icon!,
             isEthereumBased: entity.isEthereumBased
         )

--- a/fearless/Common/Model/ChainRegistry/ChainModelMapper.swift
+++ b/fearless/Common/Model/ChainRegistry/ChainModelMapper.swift
@@ -38,12 +38,20 @@ extension ChainModelMapper: CoreDataMapperProtocol {
             )
         } ?? []
 
+        let types: ChainModel.TypesSettings?
+
+        if let url = entity.types, let overridesCommon = entity.typesOverrideCommon {
+            types = .init(url: url, overridesCommon: overridesCommon.boolValue)
+        } else {
+            types = nil
+        }
+
         return ChainModel(
             chainId: entity.chainId!,
             assets: assets,
             nodes: nodes,
             addressPrefix: UInt16(bitPattern: entity.addressPrefix),
-            types: entity.types,
+            types: types,
             icon: entity.icon!,
             isEthereumBased: entity.isEthereumBased
         )
@@ -51,7 +59,9 @@ extension ChainModelMapper: CoreDataMapperProtocol {
 
     func populate(entity: CDChain, from model: ChainModel, using context: NSManagedObjectContext) throws {
         entity.chainId = model.chainId
-        entity.types = model.types
+        entity.types = model.types?.url
+        entity.typesOverrideCommon = model.types.map { NSNumber(value: $0.overridesCommon) }
+
         entity.addressPrefix = Int16(bitPattern: model.addressPrefix)
         entity.icon = model.icon
         entity.isEthereumBased = model.isEthereumBased

--- a/fearless/Common/Services/ChainRegistry/ChainRegistryFactory.swift
+++ b/fearless/Common/Services/ChainRegistry/ChainRegistryFactory.swift
@@ -7,8 +7,21 @@ final class ChainRegistryFactory {
 
         let runtimVersionRepository: CoreDataRepository<RuntimeMetadataItem, CDRuntimeMetadataItem> =
             repositoryFacade.createRepository()
+
+        let dataFetchOperationFactory = DataOperationFactory()
+
+        let topDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first ??
+            FileManager.default.temporaryDirectory
+        let runtimeDirectory = topDirectory.appendingPathComponent("runtime").path
+        let filesOperationFactory = RuntimeFilesOperationFactory(
+            repository: FileRepository(),
+            directoryPath: runtimeDirectory
+        )
+
         let runtimeSyncService = RuntimeSyncService(
-            repository: AnyDataProviderRepository(runtimVersionRepository)
+            repository: AnyDataProviderRepository(runtimVersionRepository),
+            filesOperationFactory: filesOperationFactory,
+            dataOperationFactory: dataFetchOperationFactory
         )
 
         let runtimeProviderFactory = RuntimeProviderFactory(runtimeSyncService: runtimeSyncService)
@@ -40,7 +53,7 @@ final class ChainRegistryFactory {
 
         let chainSyncService = ChainSyncService(
             url: ApplicationConfig.shared.chainListURL,
-            dataFetchFactory: DataOperationFactory(),
+            dataFetchFactory: dataFetchOperationFactory,
             repository: AnyDataProviderRepository(chainRepository),
             eventCenter: EventCenter.shared,
             operationQueue: OperationManagerFacade.sharedQueue

--- a/fearless/Common/Services/ChainRegistry/ChainRegistryFactory.swift
+++ b/fearless/Common/Services/ChainRegistry/ChainRegistryFactory.swift
@@ -21,7 +21,8 @@ final class ChainRegistryFactory {
         let runtimeSyncService = RuntimeSyncService(
             repository: AnyDataProviderRepository(runtimVersionRepository),
             filesOperationFactory: filesOperationFactory,
-            dataOperationFactory: dataFetchOperationFactory
+            dataOperationFactory: dataFetchOperationFactory,
+            eventCenter: EventCenter.shared
         )
 
         let runtimeProviderFactory = RuntimeProviderFactory(runtimeSyncService: runtimeSyncService)

--- a/fearless/Common/Services/ChainRegistry/RuntimeFilesOperationFactory.swift
+++ b/fearless/Common/Services/ChainRegistry/RuntimeFilesOperationFactory.swift
@@ -1,0 +1,79 @@
+import Foundation
+import RobinHood
+
+protocol RuntimeFilesOperationFactoryProtocol {
+    func fetchBaseTypesOperation() -> CompoundOperationWrapper<Data?>
+    func fetchChainTypesOperation(for chainId: ChainModel.Id) -> CompoundOperationWrapper<Data?>
+
+    func saveBaseTypesOperation(
+        data closure: @escaping () throws -> Data
+    ) -> CompoundOperationWrapper<Void>
+
+    func saveChainTypesOperation(
+        for chainId: ChainModel.Id,
+        data closure: @escaping () throws -> Data
+    ) -> CompoundOperationWrapper<Void>
+}
+
+final class RuntimeFilesOperationFactory {
+    let repository: FileRepositoryProtocol
+    let directoryPath: String
+
+    init(repository: FileRepositoryProtocol, directoryPath: String) {
+        self.repository = repository
+        self.directoryPath = directoryPath
+    }
+
+    private func fetchFileOperation(for fileName: String) -> CompoundOperationWrapper<Data?> {
+        let createDirOperation = repository.createDirectoryIfNeededOperation(at: directoryPath)
+
+        let filePath = (directoryPath as NSString).appendingPathComponent(fileName)
+
+        let readOperation = repository.readOperation(at: filePath)
+        readOperation.addDependency(createDirOperation)
+
+        return CompoundOperationWrapper(
+            targetOperation: readOperation,
+            dependencies: [createDirOperation]
+        )
+    }
+
+    private func saveFileOperation(
+        for fileName: String,
+        data: @escaping () throws -> Data
+    ) -> CompoundOperationWrapper<Void> {
+        let createDirOperation = repository.createDirectoryIfNeededOperation(at: directoryPath)
+
+        let filePath = (directoryPath as NSString).appendingPathComponent(fileName)
+
+        let writeOperation = repository.writeOperation(dataClosure: data, at: filePath)
+        writeOperation.addDependency(createDirOperation)
+
+        return CompoundOperationWrapper(
+            targetOperation: writeOperation,
+            dependencies: [createDirOperation]
+        )
+    }
+}
+
+extension RuntimeFilesOperationFactory: RuntimeFilesOperationFactoryProtocol {
+    func fetchBaseTypesOperation() -> CompoundOperationWrapper<Data?> {
+        fetchFileOperation(for: "base-types")
+    }
+
+    func fetchChainTypesOperation(for chainId: ChainModel.Id) -> CompoundOperationWrapper<Data?> {
+        fetchFileOperation(for: "\(chainId)-types")
+    }
+
+    func saveBaseTypesOperation(
+        data closure: @escaping () throws -> Data
+    ) -> CompoundOperationWrapper<Void> {
+        saveFileOperation(for: "base-types", data: closure)
+    }
+
+    func saveChainTypesOperation(
+        for chainId: ChainModel.Id, data closure: @escaping () throws -> Data
+    ) -> CompoundOperationWrapper<Void> {
+        saveFileOperation(for: "\(chainId)-types", data: closure)
+    }
+}

--- a/fearless/Common/Services/ChainRegistry/RuntimeProviderPool/RuntimeSyncService.swift
+++ b/fearless/Common/Services/ChainRegistry/RuntimeProviderPool/RuntimeSyncService.swift
@@ -347,12 +347,12 @@ extension RuntimeSyncService: RuntimeSyncServiceProtocol {
         }
 
         guard let syncInfo = knownChains[chain.chainId] else {
-            knownChains[chain.chainId] = SyncInfo(typesURL: chain.types, connection: connection)
+            knownChains[chain.chainId] = SyncInfo(typesURL: chain.types?.url, connection: connection)
             return
         }
 
-        if syncInfo.typesURL != chain.types {
-            knownChains[chain.chainId] = SyncInfo(typesURL: chain.types, connection: connection)
+        if syncInfo.typesURL != chain.types?.url {
+            knownChains[chain.chainId] = SyncInfo(typesURL: chain.types?.url, connection: connection)
 
             performSync(for: chain.chainId, shouldSyncTypes: true)
         }

--- a/fearless/Common/Services/ChainRegistry/RuntimeSyncService.swift
+++ b/fearless/Common/Services/ChainRegistry/RuntimeSyncService.swift
@@ -1,28 +1,42 @@
 import Foundation
 import RobinHood
+import FearlessUtils
 
 protocol RuntimeSyncServiceProtocol {
     func register(chain: ChainModel, with connection: ChainConnection)
     func apply(version: RuntimeVersion, for chainId: ChainModel.Id)
 }
 
+enum RuntimeSyncServiceError: Error {
+    case skipMetadataUnchanged
+}
+
 final class RuntimeSyncService {
     struct SyncInfo {
-        let typesURL: URL
+        let typesURL: URL?
         let connection: JSONRPCEngine
     }
 
     let repository: AnyDataProviderRepository<RuntimeMetadataItem>
+    let filesOperationFactory: RuntimeFilesOperationFactoryProtocol
+    let dataOperationFactory: DataOperationFactoryProtocol
     let operationQueue: OperationQueue
+    let dataHasher: StorageHasher
 
     private(set) var knownChains: [ChainModel.Id: SyncInfo] = [:]
     private var mutex = NSLock()
 
     init(
         repository: AnyDataProviderRepository<RuntimeMetadataItem>,
-        maxConcurrentSyncRequests: Int = 8
+        filesOperationFactory: RuntimeFilesOperationFactoryProtocol,
+        dataOperationFactory: DataOperationFactoryProtocol,
+        maxConcurrentSyncRequests: Int = 8,
+        dataHasher: StorageHasher = .twox256
     ) {
         self.repository = repository
+        self.filesOperationFactory = filesOperationFactory
+        self.dataOperationFactory = dataOperationFactory
+        self.dataHasher = dataHasher
 
         let operationQueue = OperationQueue()
         operationQueue.maxConcurrentOperationCount = maxConcurrentSyncRequests
@@ -30,8 +44,147 @@ final class RuntimeSyncService {
         self.operationQueue = operationQueue
     }
 
-    private func performSync(for _: ChainModel.Id, newVersion _: RuntimeVersion? = nil) {
-        // TODO: Will be implemented in FLW-1193
+    private func performSync(
+        for chainId: ChainModel.Id,
+        shouldSyncTypes: Bool,
+        newVersion: RuntimeVersion? = nil
+    ) {
+        guard let syncInfo = knownChains[chainId] else {
+            return
+        }
+
+        let chainTypesSyncWrapper = shouldSyncTypes ? syncInfo.typesURL.map {
+            createChainTypesSyncOperation(chainId, hasher: dataHasher, url: $0)
+        } : nil
+
+        let metadataSyncWrapper = newVersion.map {
+            createMetadataSyncOperation(for: chainId, runtimeVersion: $0, connection: syncInfo.connection)
+        }
+
+        if chainTypesSyncWrapper == nil, metadataSyncWrapper == nil {
+            // TODO: Handle nothing todo case
+            return
+        }
+
+        let dependencies = (chainTypesSyncWrapper?.allOperations ?? []) +
+            (metadataSyncWrapper?.allOperations ?? [])
+
+        let processingOperation = ClosureOperation<Void> {}
+
+        dependencies.forEach { processingOperation.addDependency($0) }
+
+        processingOperation.completionBlock = { [weak self] in
+            DispatchQueue.global().async {
+                self?.processSyncResult(
+                    for: chainTypesSyncWrapper?.targetOperation.result,
+                    metadataSyncResult: metadataSyncWrapper?.targetOperation.result,
+                    runtimeVersion: newVersion
+                )
+            }
+        }
+
+        operationQueue.addOperations(dependencies + [processingOperation], waitUntilFinished: false)
+    }
+
+    private func processSyncResult(
+        for typesSyncResult: Result<String, Error>?,
+        metadataSyncResult: Result<Void, Error>?,
+        runtimeVersion: RuntimeVersion?
+    ) {
+        mutex.lock()
+
+        defer {
+            mutex.unlock()
+        }
+    }
+
+    private func createChainTypesSyncOperation(
+        _ chainId: ChainModel.Id,
+        hasher: StorageHasher,
+        url: URL
+    ) -> CompoundOperationWrapper<String> {
+        let remoteFileOperation = dataOperationFactory.fetchData(from: url)
+
+        let fileSaveWrapper = filesOperationFactory.saveChainTypesOperation(for: chainId) {
+            try remoteFileOperation.extractNoCancellableResultData()
+        }
+
+        fileSaveWrapper.addDependency(operations: [remoteFileOperation])
+
+        let mapOperation = ClosureOperation<String> {
+            _ = try fileSaveWrapper.targetOperation.extractNoCancellableResultData()
+            let data = try remoteFileOperation.extractNoCancellableResultData()
+
+            return try hasher.hash(data: data).toHex()
+        }
+
+        mapOperation.addDependency(fileSaveWrapper.targetOperation)
+        mapOperation.addDependency(remoteFileOperation)
+
+        return CompoundOperationWrapper(
+            targetOperation: mapOperation,
+            dependencies: [remoteFileOperation] + fileSaveWrapper.allOperations
+        )
+    }
+
+    private func createMetadataSyncOperation(
+        for chainId: ChainModel.Id,
+        runtimeVersion: RuntimeVersion,
+        connection: JSONRPCEngine
+    ) -> CompoundOperationWrapper<Void> {
+        let localMetadataOperation = repository.fetchOperation(
+            by: chainId,
+            options: RepositoryFetchOptions()
+        )
+
+        let remoteMetadaOperation = JSONRPCOperation<[String], String>(
+            engine: connection,
+            method: RPCMethod.getRuntimeMetadata
+        )
+
+        remoteMetadaOperation.configurationBlock = {
+            do {
+                let currentItem = try localMetadataOperation
+                    .extractResultData(throwing: BaseOperationError.parentOperationCancelled)
+                if let item = currentItem, item.version == runtimeVersion.specVersion {
+                    remoteMetadaOperation.result = .failure(RuntimeSyncServiceError.skipMetadataUnchanged)
+                }
+            } catch {
+                remoteMetadaOperation.result = .failure(error)
+            }
+        }
+
+        remoteMetadaOperation.addDependency(localMetadataOperation)
+
+        let saveMetadataOperation = repository.saveOperation({
+            let hexMetadata = try remoteMetadaOperation.extractNoCancellableResultData()
+            let rawMetadata = try Data(hexString: hexMetadata)
+            let metadataItem = RuntimeMetadataItem(
+                chain: chainId,
+                version: runtimeVersion.specVersion,
+                txVersion: runtimeVersion.transactionVersion,
+                metadata: rawMetadata
+            )
+
+            return [metadataItem]
+        }, { [] })
+
+        saveMetadataOperation.addDependency(remoteMetadaOperation)
+
+        let filterOperation = ClosureOperation<Void> {
+            do {
+                _ = try saveMetadataOperation.extractNoCancellableResultData()
+            } catch let error as RuntimeSyncServiceError where error == .skipMetadataUnchanged {
+                return
+            }
+        }
+
+        filterOperation.addDependency(saveMetadataOperation)
+
+        return CompoundOperationWrapper(
+            targetOperation: filterOperation,
+            dependencies: [localMetadataOperation, remoteMetadaOperation, saveMetadataOperation]
+        )
     }
 }
 
@@ -51,7 +204,7 @@ extension RuntimeSyncService: RuntimeSyncServiceProtocol {
         if syncInfo.typesURL != chain.types {
             knownChains[chain.chainId] = SyncInfo(typesURL: chain.types, connection: connection)
 
-            performSync(for: chain.chainId)
+            performSync(for: chain.chainId, shouldSyncTypes: true)
         }
     }
 
@@ -62,6 +215,6 @@ extension RuntimeSyncService: RuntimeSyncServiceProtocol {
             mutex.unlock()
         }
 
-        performSync(for: chainId, newVersion: version)
+        performSync(for: chainId, shouldSyncTypes: true, newVersion: version)
     }
 }

--- a/fearless/Common/Services/ChainRegistry/RuntimeSyncService.swift
+++ b/fearless/Common/Services/ChainRegistry/RuntimeSyncService.swift
@@ -58,7 +58,11 @@ final class RuntimeSyncService {
         } : nil
 
         let metadataSyncWrapper = newVersion.map {
-            createMetadataSyncOperation(for: chainId, runtimeVersion: $0, connection: syncInfo.connection)
+            createMetadataSyncOperation(
+                for: chainId,
+                runtimeVersion: $0,
+                connection: syncInfo.connection
+            )
         }
 
         if chainTypesSyncWrapper == nil, metadataSyncWrapper == nil {
@@ -96,6 +100,36 @@ final class RuntimeSyncService {
         defer {
             mutex.unlock()
         }
+
+        addRetryRequestIfNeeded(
+            for: typesSyncResult,
+            metadataSyncResult: metadataSyncResult,
+            runtimeVersion: runtimeVersion
+        )
+
+        DispatchQueue.main.async { [weak self] in
+            self?.notifyCompletion(
+                for: typesSyncResult,
+                metadataSyncResult: metadataSyncResult,
+                runtimeVersion: runtimeVersion
+            )
+        }
+    }
+
+    private func addRetryRequestIfNeeded(
+        for typesSyncResult: Result<String, Error>?,
+        metadataSyncResult: Result<Void, Error>?,
+        runtimeVersion: RuntimeVersion?
+    ) {
+
+    }
+
+    private func notifyCompletion(
+        for typesSyncResult: Result<String, Error>?,
+        metadataSyncResult: Result<Void, Error>?,
+        runtimeVersion: RuntimeVersion?
+    ) {
+
     }
 
     private func createChainTypesSyncOperation(

--- a/fearless/Common/Storage/SubstrateDataModel.xcdatamodeld/SubstrateDataModel.xcdatamodel/contents
+++ b/fearless/Common/Storage/SubstrateDataModel.xcdatamodeld/SubstrateDataModel.xcdatamodel/contents
@@ -14,6 +14,7 @@
         <attribute name="icon" attributeType="URI"/>
         <attribute name="isEthereumBased" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="types" optional="YES" attributeType="URI"/>
+        <attribute name="typesOverrideCommon" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
         <relationship name="assets" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="CDAsset" inverseName="chain" inverseEntity="CDAsset"/>
         <relationship name="nodes" optional="YES" toMany="YES" minCount="1" deletionRule="Cascade" destinationEntity="CDChainNode" inverseName="chain" inverseEntity="CDChainNode"/>
         <uniquenessConstraints>
@@ -77,7 +78,7 @@
     </entity>
     <elements>
         <element name="CDAsset" positionX="-36" positionY="90" width="128" height="119"/>
-        <element name="CDChain" positionX="-45" positionY="81" width="128" height="134"/>
+        <element name="CDChain" positionX="-45" positionY="81" width="128" height="149"/>
         <element name="CDChainNode" positionX="-27" positionY="99" width="128" height="74"/>
         <element name="CDChainStorageItem" positionX="-54" positionY="-9" width="128" height="73"/>
         <element name="CDContactItem" positionX="-45" positionY="81" width="128" height="118"/>

--- a/fearlessTests/Common/Services/ChainRegistry/ChainModelGenerator.swift
+++ b/fearlessTests/Common/Services/ChainRegistry/ChainModelGenerator.swift
@@ -2,7 +2,7 @@ import Foundation
 @testable import fearless
 
 final class ChainModelGenerator {
-    static func generate(count: Int) -> [ChainModel] {
+    static func generate(count: Int, withTypes: Bool = true) -> [ChainModel] {
         (0..<count).map { index in
             let chainId = Data.random(of: 32)!.toHex()
 
@@ -26,7 +26,7 @@ final class ChainModelGenerator {
                 assets: [asset],
                 nodes: [node],
                 addressPrefix: UInt16(index),
-                types: URL(string: "https://github.com")!,
+                types: withTypes ? URL(string: "https://github.com")! : nil,
                 icon: URL(string: "https://github.com")!,
                 isEthereumBased: false
             )

--- a/fearlessTests/Common/Services/ChainRegistry/ChainModelGenerator.swift
+++ b/fearlessTests/Common/Services/ChainRegistry/ChainModelGenerator.swift
@@ -21,12 +21,17 @@ final class ChainModelGenerator {
                 name: chainId
             )
 
+            let types = withTypes ? ChainModel.TypesSettings(
+                url: URL(string: "https://github.com")!,
+                overridesCommon: false
+            ) : nil
+
             return ChainModel(
                 chainId: chainId,
                 assets: [asset],
                 nodes: [node],
                 addressPrefix: UInt16(index),
-                types: withTypes ? URL(string: "https://github.com")! : nil,
+                types: types,
                 icon: URL(string: "https://github.com")!,
                 isEthereumBased: false
             )

--- a/fearlessTests/Common/Services/ChainRegistry/RuntimeSyncServiceTests.swift
+++ b/fearlessTests/Common/Services/ChainRegistry/RuntimeSyncServiceTests.swift
@@ -1,0 +1,552 @@
+import XCTest
+@testable import fearless
+import Cuckoo
+import RobinHood
+
+class RuntimeSyncServiceTests: XCTestCase {
+    func testChainRegisterationAndUnregistration() {
+        // given
+
+        let storageFacade = SubstrateStorageTestFacade()
+        let metadataRepository: CoreDataRepository<RuntimeMetadataItem, CDRuntimeMetadataItem> =
+            storageFacade.createRepository()
+        let filesOperationFactory = MockRuntimeFilesOperationFactoryProtocol()
+        let dataOperationFactory = MockDataOperationFactoryProtocol()
+        let eventCenter = MockEventCenterProtocol()
+        let connection = MockConnection()
+
+        let syncService = RuntimeSyncService(repository: AnyDataProviderRepository(metadataRepository),
+                                             filesOperationFactory: filesOperationFactory,
+                                             dataOperationFactory: dataOperationFactory,
+                                             eventCenter: eventCenter
+        )
+
+        let chainCount = 10
+        let chains = ChainModelGenerator.generate(count: chainCount)
+
+        let unregisterChains = Set(chains.prefix(chainCount / 2))
+        let remainingChains = Set(chains.suffix(chains.count - unregisterChains.count))
+
+        // when
+
+        chains.forEach { syncService.register(chain: $0, with: connection) }
+
+        // then
+
+        XCTAssertTrue(chains.allSatisfy { syncService.hasChain(with: $0.chainId) })
+        XCTAssertTrue(chains.allSatisfy { !syncService.isChainSyncing($0.chainId) })
+
+        // when
+
+        unregisterChains.forEach { syncService.unregister(chainId: $0.chainId) }
+
+        // then
+
+        XCTAssertTrue(remainingChains.allSatisfy { syncService.hasChain(with: $0.chainId) })
+        XCTAssertTrue(unregisterChains.allSatisfy { !syncService.hasChain(with: $0.chainId) })
+    }
+
+    func testTypesAndMetadataSyncSuccess() throws {
+        // given
+
+        let storageFacade = SubstrateStorageTestFacade()
+        let metadataRepository: CoreDataRepository<RuntimeMetadataItem, CDRuntimeMetadataItem> =
+            storageFacade.createRepository()
+        let filesOperationFactory = MockRuntimeFilesOperationFactoryProtocol()
+        let dataOperationFactory = MockDataOperationFactoryProtocol()
+        let eventCenter = MockEventCenterProtocol()
+
+        let syncService = RuntimeSyncService(repository: AnyDataProviderRepository(metadataRepository),
+                                             filesOperationFactory: filesOperationFactory,
+                                             dataOperationFactory: dataOperationFactory,
+                                             eventCenter: eventCenter
+        )
+
+        // when
+
+        let chainCount = 10
+        let chains = ChainModelGenerator.generate(count: chainCount)
+
+        let connections = chains.reduce(into: [ChainModel.Id: MockConnection]()) { (storage, chain) in
+            storage[chain.chainId] = MockConnection()
+        }
+
+        let runtimeMetadataItems = chains.reduce(into: [ChainModel.Id: Data]()) { (storage, chain) in
+            storage[chain.chainId] = Data.random(of: 128)!
+        }
+
+        // stub chain types file fetch from remote source
+
+        stub(dataOperationFactory) { stub in
+            stub.fetchData(from: any()).then { _ in
+                let responseData = Data.random(of: 1024)!
+                return BaseOperation.createWithResult(responseData)
+            }
+        }
+
+        // stub chain types file save to disk
+
+        stub(filesOperationFactory) { stub in
+            stub.saveChainTypesOperation(for: any(), data: any()).then { (chainId, data) in
+                CompoundOperationWrapper.createWithResult(())
+            }
+        }
+
+        // stub runtime metadata fetch
+
+        connections.forEach { (chainId, connection) in
+            stub(connection.internalConnection) { stub in
+                stub.callMethod(any(), params: any([String].self), options: any(), completion: any())
+                    .then { (_, _, _, completion: ((Result<String, Error>) -> Void)?) in
+                        DispatchQueue.global().async {
+                            let responseData = runtimeMetadataItems[chainId]!.toHex(includePrefix: true)
+                            completion?(.success(responseData))
+                        }
+
+                        return (0...UInt16.max).randomElement()!
+                }
+            }
+        }
+
+        let completionExpectation = XCTestExpectation()
+        completionExpectation.expectedFulfillmentCount = 2 * chainCount
+        completionExpectation.assertForOverFulfill = true
+
+        var syncedTypesChainIds: Set<ChainModel.Id> = Set()
+        var syncedMetadataChainIds: Set<ChainModel.Id> = Set()
+
+        // catch all sync completion events
+
+        stub(eventCenter) { stub in
+            stub.notify(with: any()).then { event in
+                if let syncEvent = event as? RuntimeChainTypesSyncCompleted {
+                    syncedTypesChainIds.insert(syncEvent.chainId)
+                }
+
+                if let syncEvent = event as? RuntimeMetadataSyncCompleted {
+                    syncedMetadataChainIds.insert(syncEvent.chainId)
+                }
+
+                completionExpectation.fulfill()
+            }
+        }
+
+        chains.forEach { chain in
+            syncService.register(chain: chain, with: connections[chain.chainId]!)
+            syncService.apply(
+                version: RuntimeVersion(specVersion: 1, transactionVersion: 1),
+                for: chain.chainId
+            )
+
+            XCTAssertTrue(syncService.isChainSyncing(chain.chainId))
+        }
+
+        // then
+
+        wait(for: [completionExpectation], timeout: 10)
+
+        let expectedChainIds = Set(chains.map { $0.chainId })
+
+        XCTAssertEqual(expectedChainIds, syncedTypesChainIds)
+        XCTAssertEqual(expectedChainIds, syncedMetadataChainIds)
+
+        // make sure files are saved
+
+        verify(filesOperationFactory, times(chainCount)).saveChainTypesOperation(for: any(), data: any())
+
+        // make sure metadata is saved for each chain
+
+        let allMetadataOperation = metadataRepository.fetchAllOperation(with: RepositoryFetchOptions())
+        OperationQueue().addOperations([allMetadataOperation], waitUntilFinished: true)
+
+        let actualMetadataItems = try allMetadataOperation.extractNoCancellableResultData()
+        XCTAssertEqual(actualMetadataItems.count, chainCount)
+
+        for actualMetadataItem in actualMetadataItems {
+            XCTAssertEqual(actualMetadataItem.metadata, runtimeMetadataItems[actualMetadataItem.chain]!)
+        }
+    }
+
+    func testOnlyMetadataSyncSuccess() throws {
+        // given
+
+        let storageFacade = SubstrateStorageTestFacade()
+        let metadataRepository: CoreDataRepository<RuntimeMetadataItem, CDRuntimeMetadataItem> =
+            storageFacade.createRepository()
+        let filesOperationFactory = MockRuntimeFilesOperationFactoryProtocol()
+        let dataOperationFactory = MockDataOperationFactoryProtocol()
+        let eventCenter = MockEventCenterProtocol()
+
+        let syncService = RuntimeSyncService(repository: AnyDataProviderRepository(metadataRepository),
+                                             filesOperationFactory: filesOperationFactory,
+                                             dataOperationFactory: dataOperationFactory,
+                                             eventCenter: eventCenter
+        )
+
+        // when
+
+        let chainCount = 10
+        let chains = ChainModelGenerator.generate(count: chainCount, withTypes: false)
+
+        let connections = chains.reduce(into: [ChainModel.Id: MockConnection]()) { (storage, chain) in
+            storage[chain.chainId] = MockConnection()
+        }
+
+        let runtimeMetadataItems = chains.reduce(into: [ChainModel.Id: Data]()) { (storage, chain) in
+            storage[chain.chainId] = Data.random(of: 128)!
+        }
+
+        // stub runtime metadata fetch
+
+        connections.forEach { (chainId, connection) in
+            stub(connection.internalConnection) { stub in
+                stub.callMethod(any(), params: any([String].self), options: any(), completion: any())
+                    .then { (_, _, _, completion: ((Result<String, Error>) -> Void)?) in
+                        DispatchQueue.global().async {
+                            let responseData = runtimeMetadataItems[chainId]!.toHex(includePrefix: true)
+                            completion?(.success(responseData))
+                        }
+
+                        return (0...UInt16.max).randomElement()!
+                }
+            }
+        }
+
+        let completionExpectation = XCTestExpectation()
+        completionExpectation.expectedFulfillmentCount = chainCount
+        completionExpectation.assertForOverFulfill = true
+
+        var syncedMetadataChainIds: Set<ChainModel.Id> = Set()
+
+        // catch all sync completion events
+
+        stub(eventCenter) { stub in
+            stub.notify(with: any()).then { event in
+                if let syncEvent = event as? RuntimeMetadataSyncCompleted {
+                    syncedMetadataChainIds.insert(syncEvent.chainId)
+                }
+
+                completionExpectation.fulfill()
+            }
+        }
+
+        chains.forEach { chain in
+            syncService.register(chain: chain, with: connections[chain.chainId]!)
+            syncService.apply(
+                version: RuntimeVersion(specVersion: 1, transactionVersion: 1),
+                for: chain.chainId
+            )
+
+            XCTAssertTrue(syncService.isChainSyncing(chain.chainId))
+        }
+
+        // then
+
+        wait(for: [completionExpectation], timeout: 10)
+
+        let expectedChainIds = Set(chains.map { $0.chainId })
+
+        XCTAssertEqual(expectedChainIds, syncedMetadataChainIds)
+
+        // make sure metadata is saved for each chain
+
+        let allMetadataOperation = metadataRepository.fetchAllOperation(with: RepositoryFetchOptions())
+        OperationQueue().addOperations([allMetadataOperation], waitUntilFinished: true)
+
+        let actualMetadataItems = try allMetadataOperation.extractNoCancellableResultData()
+        XCTAssertEqual(actualMetadataItems.count, chainCount)
+
+        for actualMetadataItem in actualMetadataItems {
+            XCTAssertEqual(actualMetadataItem.metadata, runtimeMetadataItems[actualMetadataItem.chain]!)
+        }
+    }
+
+    func testTypesAndMetadataFailureRetry() throws {
+        // given
+
+        let storageFacade = SubstrateStorageTestFacade()
+        let metadataRepository: CoreDataRepository<RuntimeMetadataItem, CDRuntimeMetadataItem> =
+            storageFacade.createRepository()
+        let filesOperationFactory = MockRuntimeFilesOperationFactoryProtocol()
+        let dataOperationFactory = MockDataOperationFactoryProtocol()
+        let eventCenter = MockEventCenterProtocol()
+
+        let syncService = RuntimeSyncService(repository: AnyDataProviderRepository(metadataRepository),
+                                             filesOperationFactory: filesOperationFactory,
+                                             dataOperationFactory: dataOperationFactory,
+                                             eventCenter: eventCenter
+        )
+
+        // when
+
+        let chainCount = 10
+        let chains = ChainModelGenerator.generate(count: chainCount)
+
+        let connections = chains.reduce(into: [ChainModel.Id: MockConnection]()) { (storage, chain) in
+            storage[chain.chainId] = MockConnection()
+        }
+
+        let runtimeMetadataItems = chains.reduce(into: [ChainModel.Id: Data]()) { (storage, chain) in
+            storage[chain.chainId] = Data.random(of: 128)!
+        }
+
+        // stub chain types file fetch from remote source
+
+        var failureCounterForTypes: Int = 0
+
+        stub(dataOperationFactory) { stub in
+            stub.fetchData(from: any()).then { _ in
+                if failureCounterForTypes < chainCount {
+                    failureCounterForTypes += 1
+
+                    return BaseOperation.createWithError(BaseOperationError.unexpectedDependentResult)
+                } else {
+                    let responseData = Data.random(of: 1024)!
+                    return BaseOperation.createWithResult(responseData)
+                }
+            }
+        }
+
+        // stub chain types file save to disk
+
+        stub(filesOperationFactory) { stub in
+            stub.saveChainTypesOperation(for: any(), data: any()).then { (chainId, data) in
+                CompoundOperationWrapper.createWithResult(())
+            }
+        }
+
+        // stub runtime metadata fetch
+
+        var failureCounterForMetadata: Int = 0
+
+        connections.forEach { (chainId, connection) in
+            stub(connection.internalConnection) { stub in
+                stub.callMethod(any(), params: any([String].self), options: any(), completion: any())
+                    .then { (_, _, _, completion: ((Result<String, Error>) -> Void)?) in
+                        if failureCounterForMetadata < chainCount {
+                            failureCounterForMetadata += 1
+
+                            DispatchQueue.global().async {
+                                completion?(.failure(BaseOperationError.unexpectedDependentResult))
+                            }
+
+                            return (0...UInt16.max).randomElement()!
+                        } else {
+                            DispatchQueue.global().async {
+                                let responseData = runtimeMetadataItems[chainId]!.toHex(includePrefix: true)
+                                completion?(.success(responseData))
+                            }
+
+                            return (0...UInt16.max).randomElement()!
+                        }
+                }
+            }
+        }
+
+        let completionExpectation = XCTestExpectation()
+        completionExpectation.expectedFulfillmentCount = 2 * chainCount
+        completionExpectation.assertForOverFulfill = true
+
+        var syncedTypesChainIds: Set<ChainModel.Id> = Set()
+        var syncedMetadataChainIds: Set<ChainModel.Id> = Set()
+
+        // catch all sync completion events
+
+        stub(eventCenter) { stub in
+            stub.notify(with: any()).then { event in
+                if let syncEvent = event as? RuntimeChainTypesSyncCompleted {
+                    syncedTypesChainIds.insert(syncEvent.chainId)
+                }
+
+                if let syncEvent = event as? RuntimeMetadataSyncCompleted {
+                    syncedMetadataChainIds.insert(syncEvent.chainId)
+                }
+
+                completionExpectation.fulfill()
+            }
+        }
+
+        chains.forEach { chain in
+            syncService.register(chain: chain, with: connections[chain.chainId]!)
+            syncService.apply(
+                version: RuntimeVersion(specVersion: 1, transactionVersion: 1),
+                for: chain.chainId
+            )
+
+            XCTAssertTrue(syncService.isChainSyncing(chain.chainId))
+        }
+
+        // then
+
+        wait(for: [completionExpectation], timeout: 10)
+
+        let expectedChainIds = Set(chains.map { $0.chainId })
+
+        XCTAssertEqual(expectedChainIds, syncedTypesChainIds)
+        XCTAssertEqual(expectedChainIds, syncedMetadataChainIds)
+
+        // make sure files are tried to be save twice (first time and after retry)
+
+        verify(filesOperationFactory, times(2 * chainCount)).saveChainTypesOperation(
+            for: any(),
+            data: any()
+        )
+
+        // make sure metadata is saved for each chain
+
+        let allMetadataOperation = metadataRepository.fetchAllOperation(with: RepositoryFetchOptions())
+        OperationQueue().addOperations([allMetadataOperation], waitUntilFinished: true)
+
+        let actualMetadataItems = try allMetadataOperation.extractNoCancellableResultData()
+        XCTAssertEqual(actualMetadataItems.count, chainCount)
+
+        for actualMetadataItem in actualMetadataItems {
+            XCTAssertEqual(actualMetadataItem.metadata, runtimeMetadataItems[actualMetadataItem.chain]!)
+        }
+    }
+
+    func testOnlyTypesFailureRetry() throws {
+        // given
+
+        let storageFacade = SubstrateStorageTestFacade()
+        let metadataRepository: CoreDataRepository<RuntimeMetadataItem, CDRuntimeMetadataItem> =
+            storageFacade.createRepository()
+        let filesOperationFactory = MockRuntimeFilesOperationFactoryProtocol()
+        let dataOperationFactory = MockDataOperationFactoryProtocol()
+        let eventCenter = MockEventCenterProtocol()
+
+        let syncService = RuntimeSyncService(repository: AnyDataProviderRepository(metadataRepository),
+                                             filesOperationFactory: filesOperationFactory,
+                                             dataOperationFactory: dataOperationFactory,
+                                             eventCenter: eventCenter
+        )
+
+        // when
+
+        let chainCount = 10
+        let chains = ChainModelGenerator.generate(count: chainCount)
+
+        let connections = chains.reduce(into: [ChainModel.Id: MockConnection]()) { (storage, chain) in
+            storage[chain.chainId] = MockConnection()
+        }
+
+        let runtimeMetadataItems = chains.reduce(into: [ChainModel.Id: Data]()) { (storage, chain) in
+            storage[chain.chainId] = Data.random(of: 128)!
+        }
+
+        // stub chain types file fetch from remote source
+
+        var failureCounterForTypes: Int = 0
+
+        stub(dataOperationFactory) { stub in
+            stub.fetchData(from: any()).then { _ in
+                if failureCounterForTypes < chainCount {
+                    failureCounterForTypes += 1
+
+                    return BaseOperation.createWithError(BaseOperationError.unexpectedDependentResult)
+                } else {
+                    let responseData = Data.random(of: 1024)!
+                    return BaseOperation.createWithResult(responseData)
+                }
+            }
+        }
+
+        // stub chain types file save to disk
+
+        stub(filesOperationFactory) { stub in
+            stub.saveChainTypesOperation(for: any(), data: any()).then { (chainId, data) in
+                CompoundOperationWrapper.createWithResult(())
+            }
+        }
+
+        // stub runtime metadata fetch
+
+        connections.forEach { (chainId, connection) in
+            stub(connection.internalConnection) { stub in
+                stub.callMethod(any(), params: any([String].self), options: any(), completion: any())
+                    .then { (_, _, _, completion: ((Result<String, Error>) -> Void)?) in
+                        DispatchQueue.global().async {
+                            let responseData = runtimeMetadataItems[chainId]!.toHex(includePrefix: true)
+                            completion?(.success(responseData))
+                        }
+
+                        return (0...UInt16.max).randomElement()!
+                }
+            }
+        }
+
+        let completionExpectation = XCTestExpectation()
+        completionExpectation.expectedFulfillmentCount = 2 * chainCount
+        completionExpectation.assertForOverFulfill = true
+
+        var syncedTypesChainIds: Set<ChainModel.Id> = Set()
+        var syncedMetadataChainIds: Set<ChainModel.Id> = Set()
+
+        // catch all sync completion events
+
+        stub(eventCenter) { stub in
+            stub.notify(with: any()).then { event in
+                if let syncEvent = event as? RuntimeChainTypesSyncCompleted {
+                    syncedTypesChainIds.insert(syncEvent.chainId)
+                }
+
+                if let syncEvent = event as? RuntimeMetadataSyncCompleted {
+                    syncedMetadataChainIds.insert(syncEvent.chainId)
+                }
+
+                completionExpectation.fulfill()
+            }
+        }
+
+        chains.forEach { chain in
+            syncService.register(chain: chain, with: connections[chain.chainId]!)
+            syncService.apply(
+                version: RuntimeVersion(specVersion: 1, transactionVersion: 1),
+                for: chain.chainId
+            )
+
+            XCTAssertTrue(syncService.isChainSyncing(chain.chainId))
+        }
+
+        // then
+
+        wait(for: [completionExpectation], timeout: 10)
+
+        let expectedChainIds = Set(chains.map { $0.chainId })
+
+        XCTAssertEqual(expectedChainIds, syncedTypesChainIds)
+        XCTAssertEqual(expectedChainIds, syncedMetadataChainIds)
+
+        // make sure files are tried to be save twice (first time and after retry)
+
+        verify(filesOperationFactory, times(2 * chainCount)).saveChainTypesOperation(
+            for: any(),
+            data: any()
+        )
+
+        // make sure metadata requested once
+
+        let completionMatcher: ParameterMatcher<((Result<String, Error>) -> Void)?> = anyClosure()
+
+        for (_, connection) in connections {
+            verify(connection.internalConnection, times(1)).callMethod(
+                any(),
+                params: any([String].self),
+                options: any(),
+                completion: completionMatcher
+            )
+        }
+
+        // make sure metadata is saved for each chain
+
+        let allMetadataOperation = metadataRepository.fetchAllOperation(with: RepositoryFetchOptions())
+        OperationQueue().addOperations([allMetadataOperation], waitUntilFinished: true)
+
+        let actualMetadataItems = try allMetadataOperation.extractNoCancellableResultData()
+        XCTAssertEqual(actualMetadataItems.count, chainCount)
+
+        for actualMetadataItem in actualMetadataItems {
+            XCTAssertEqual(actualMetadataItem.metadata, runtimeMetadataItems[actualMetadataItem.chain]!)
+        }
+    }
+}

--- a/fearlessTests/Mocks/CommonMocks.swift
+++ b/fearlessTests/Mocks/CommonMocks.swift
@@ -2457,3 +2457,191 @@ import Foundation
     
 }
 
+
+import Cuckoo
+@testable import fearless
+@testable import SoraKeystore
+
+import Foundation
+import RobinHood
+
+
+ class MockRuntimeFilesOperationFactoryProtocol: RuntimeFilesOperationFactoryProtocol, Cuckoo.ProtocolMock {
+    
+     typealias MocksType = RuntimeFilesOperationFactoryProtocol
+    
+     typealias Stubbing = __StubbingProxy_RuntimeFilesOperationFactoryProtocol
+     typealias Verification = __VerificationProxy_RuntimeFilesOperationFactoryProtocol
+
+     let cuckoo_manager = Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: false)
+
+    
+    private var __defaultImplStub: RuntimeFilesOperationFactoryProtocol?
+
+     func enableDefaultImplementation(_ stub: RuntimeFilesOperationFactoryProtocol) {
+        __defaultImplStub = stub
+        cuckoo_manager.enableDefaultStubImplementation()
+    }
+    
+
+    
+
+    
+
+    
+    
+    
+     func fetchBaseTypesOperation() -> CompoundOperationWrapper<Data?> {
+        
+    return cuckoo_manager.call("fetchBaseTypesOperation() -> CompoundOperationWrapper<Data?>",
+            parameters: (),
+            escapingParameters: (),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.fetchBaseTypesOperation())
+        
+    }
+    
+    
+    
+     func fetchChainTypesOperation(for chainId: ChainModel.Id) -> CompoundOperationWrapper<Data?> {
+        
+    return cuckoo_manager.call("fetchChainTypesOperation(for: ChainModel.Id) -> CompoundOperationWrapper<Data?>",
+            parameters: (chainId),
+            escapingParameters: (chainId),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.fetchChainTypesOperation(for: chainId))
+        
+    }
+    
+    
+    
+     func saveBaseTypesOperation(data closure: @escaping () throws -> Data) -> CompoundOperationWrapper<Void> {
+        
+    return cuckoo_manager.call("saveBaseTypesOperation(data: @escaping () throws -> Data) -> CompoundOperationWrapper<Void>",
+            parameters: (closure),
+            escapingParameters: (closure),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.saveBaseTypesOperation(data: closure))
+        
+    }
+    
+    
+    
+     func saveChainTypesOperation(for chainId: ChainModel.Id, data closure: @escaping () throws -> Data) -> CompoundOperationWrapper<Void> {
+        
+    return cuckoo_manager.call("saveChainTypesOperation(for: ChainModel.Id, data: @escaping () throws -> Data) -> CompoundOperationWrapper<Void>",
+            parameters: (chainId, closure),
+            escapingParameters: (chainId, closure),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.saveChainTypesOperation(for: chainId, data: closure))
+        
+    }
+    
+
+	 struct __StubbingProxy_RuntimeFilesOperationFactoryProtocol: Cuckoo.StubbingProxy {
+	    private let cuckoo_manager: Cuckoo.MockManager
+	
+	     init(manager: Cuckoo.MockManager) {
+	        self.cuckoo_manager = manager
+	    }
+	    
+	    
+	    func fetchBaseTypesOperation() -> Cuckoo.ProtocolStubFunction<(), CompoundOperationWrapper<Data?>> {
+	        let matchers: [Cuckoo.ParameterMatcher<Void>] = []
+	        return .init(stub: cuckoo_manager.createStub(for: MockRuntimeFilesOperationFactoryProtocol.self, method: "fetchBaseTypesOperation() -> CompoundOperationWrapper<Data?>", parameterMatchers: matchers))
+	    }
+	    
+	    func fetchChainTypesOperation<M1: Cuckoo.Matchable>(for chainId: M1) -> Cuckoo.ProtocolStubFunction<(ChainModel.Id), CompoundOperationWrapper<Data?>> where M1.MatchedType == ChainModel.Id {
+	        let matchers: [Cuckoo.ParameterMatcher<(ChainModel.Id)>] = [wrap(matchable: chainId) { $0 }]
+	        return .init(stub: cuckoo_manager.createStub(for: MockRuntimeFilesOperationFactoryProtocol.self, method: "fetchChainTypesOperation(for: ChainModel.Id) -> CompoundOperationWrapper<Data?>", parameterMatchers: matchers))
+	    }
+	    
+	    func saveBaseTypesOperation<M1: Cuckoo.Matchable>(data closure: M1) -> Cuckoo.ProtocolStubFunction<(() throws -> Data), CompoundOperationWrapper<Void>> where M1.MatchedType == () throws -> Data {
+	        let matchers: [Cuckoo.ParameterMatcher<(() throws -> Data)>] = [wrap(matchable: closure) { $0 }]
+	        return .init(stub: cuckoo_manager.createStub(for: MockRuntimeFilesOperationFactoryProtocol.self, method: "saveBaseTypesOperation(data: @escaping () throws -> Data) -> CompoundOperationWrapper<Void>", parameterMatchers: matchers))
+	    }
+	    
+	    func saveChainTypesOperation<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable>(for chainId: M1, data closure: M2) -> Cuckoo.ProtocolStubFunction<(ChainModel.Id, () throws -> Data), CompoundOperationWrapper<Void>> where M1.MatchedType == ChainModel.Id, M2.MatchedType == () throws -> Data {
+	        let matchers: [Cuckoo.ParameterMatcher<(ChainModel.Id, () throws -> Data)>] = [wrap(matchable: chainId) { $0.0 }, wrap(matchable: closure) { $0.1 }]
+	        return .init(stub: cuckoo_manager.createStub(for: MockRuntimeFilesOperationFactoryProtocol.self, method: "saveChainTypesOperation(for: ChainModel.Id, data: @escaping () throws -> Data) -> CompoundOperationWrapper<Void>", parameterMatchers: matchers))
+	    }
+	    
+	}
+
+	 struct __VerificationProxy_RuntimeFilesOperationFactoryProtocol: Cuckoo.VerificationProxy {
+	    private let cuckoo_manager: Cuckoo.MockManager
+	    private let callMatcher: Cuckoo.CallMatcher
+	    private let sourceLocation: Cuckoo.SourceLocation
+	
+	     init(manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher, sourceLocation: Cuckoo.SourceLocation) {
+	        self.cuckoo_manager = manager
+	        self.callMatcher = callMatcher
+	        self.sourceLocation = sourceLocation
+	    }
+	
+	    
+	
+	    
+	    @discardableResult
+	    func fetchBaseTypesOperation() -> Cuckoo.__DoNotUse<(), CompoundOperationWrapper<Data?>> {
+	        let matchers: [Cuckoo.ParameterMatcher<Void>] = []
+	        return cuckoo_manager.verify("fetchBaseTypesOperation() -> CompoundOperationWrapper<Data?>", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+	    }
+	    
+	    @discardableResult
+	    func fetchChainTypesOperation<M1: Cuckoo.Matchable>(for chainId: M1) -> Cuckoo.__DoNotUse<(ChainModel.Id), CompoundOperationWrapper<Data?>> where M1.MatchedType == ChainModel.Id {
+	        let matchers: [Cuckoo.ParameterMatcher<(ChainModel.Id)>] = [wrap(matchable: chainId) { $0 }]
+	        return cuckoo_manager.verify("fetchChainTypesOperation(for: ChainModel.Id) -> CompoundOperationWrapper<Data?>", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+	    }
+	    
+	    @discardableResult
+	    func saveBaseTypesOperation<M1: Cuckoo.Matchable>(data closure: M1) -> Cuckoo.__DoNotUse<(() throws -> Data), CompoundOperationWrapper<Void>> where M1.MatchedType == () throws -> Data {
+	        let matchers: [Cuckoo.ParameterMatcher<(() throws -> Data)>] = [wrap(matchable: closure) { $0 }]
+	        return cuckoo_manager.verify("saveBaseTypesOperation(data: @escaping () throws -> Data) -> CompoundOperationWrapper<Void>", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+	    }
+	    
+	    @discardableResult
+	    func saveChainTypesOperation<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable>(for chainId: M1, data closure: M2) -> Cuckoo.__DoNotUse<(ChainModel.Id, () throws -> Data), CompoundOperationWrapper<Void>> where M1.MatchedType == ChainModel.Id, M2.MatchedType == () throws -> Data {
+	        let matchers: [Cuckoo.ParameterMatcher<(ChainModel.Id, () throws -> Data)>] = [wrap(matchable: chainId) { $0.0 }, wrap(matchable: closure) { $0.1 }]
+	        return cuckoo_manager.verify("saveChainTypesOperation(for: ChainModel.Id, data: @escaping () throws -> Data) -> CompoundOperationWrapper<Void>", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+	    }
+	    
+	}
+}
+
+ class RuntimeFilesOperationFactoryProtocolStub: RuntimeFilesOperationFactoryProtocol {
+    
+
+    
+
+    
+     func fetchBaseTypesOperation() -> CompoundOperationWrapper<Data?>  {
+        return DefaultValueRegistry.defaultValue(for: (CompoundOperationWrapper<Data?>).self)
+    }
+    
+     func fetchChainTypesOperation(for chainId: ChainModel.Id) -> CompoundOperationWrapper<Data?>  {
+        return DefaultValueRegistry.defaultValue(for: (CompoundOperationWrapper<Data?>).self)
+    }
+    
+     func saveBaseTypesOperation(data closure: @escaping () throws -> Data) -> CompoundOperationWrapper<Void>  {
+        return DefaultValueRegistry.defaultValue(for: (CompoundOperationWrapper<Void>).self)
+    }
+    
+     func saveChainTypesOperation(for chainId: ChainModel.Id, data closure: @escaping () throws -> Data) -> CompoundOperationWrapper<Void>  {
+        return DefaultValueRegistry.defaultValue(for: (CompoundOperationWrapper<Void>).self)
+    }
+    
+}
+


### PR DESCRIPTION
Add runtime sync service that syncs types and metadata for each chain and controls number of operations executed concurrently to prevent out of memory problems