### PR TITLE
(FLW-1635) remove validation for ethereum derivation path

### DIFF
--- a/fearless/Modules/AccountCreate/AccountCreatePresenter.swift
+++ b/fearless/Modules/AccountCreate/AccountCreatePresenter.swift
@@ -70,11 +70,11 @@ final class AccountCreatePresenter {
         processor: TextProcessing? = nil,
         maxLength: Int? = nil
     ) -> InputViewModel {
-        let predicate: NSPredicate
+        let predicate: NSPredicate?
         let placeholder: String
 
         if isEthereum {
-            predicate = NSPredicate.deriviationPathHardPassword
+            predicate = nil
             placeholder = DerivationPathConstants.defaultEthereum
         } else {
             switch cryptoType {

--- a/fearless/Modules/AccountImport/AccountImportPresenter.swift
+++ b/fearless/Modules/AccountImport/AccountImportPresenter.swift
@@ -257,17 +257,11 @@ final class AccountImportPresenter {
         processor: TextProcessing? = nil,
         maxLength: Int? = nil
     ) -> InputViewModel {
-        let predicate: NSPredicate
+        let predicate: NSPredicate?
         let placeholder: String
         if isEthereum {
-            switch (cryptoType, sourceType) {
-            case (_, .mnemonic):
-                predicate = NSPredicate.deriviationPathHardPassword
-                placeholder = DerivationPathConstants.defaultEthereum
-            default:
-                predicate = NSPredicate.deriviationPathHard
-                placeholder = DerivationPathConstants.defaultEthereum
-            }
+            predicate = nil
+            placeholder = DerivationPathConstants.defaultEthereum
         } else {
             switch (cryptoType, sourceType) {
             case (.sr25519, .mnemonic):


### PR DESCRIPTION
we don't need validation for ethereum derivation path because we have mask which guarantees valid input