### PR TITLE
Disable pagination for giantsquid

### DIFF
--- a/fearless/CoreLayer/OperationFactory/BlockExplorer/History/Main/GiantsquidHistoryOperationFactory.swift
+++ b/fearless/CoreLayer/OperationFactory/BlockExplorer/History/Main/GiantsquidHistoryOperationFactory.swift
@@ -285,7 +285,7 @@ final class GiantsquidHistoryOperationFactory {
 
             return AssetTransactionPageData(
                 transactions: mergeResult.historyItems,
-                context: [:]
+                context: nil
             )
         }
     }


### PR DESCRIPTION
In TransactionHistoryInteractor we have this condition to load next page:
`if let currentPage = currentPage, context != nil {
`

context is a parameter moved from subquery , and it's responsible for pagination info storage. in giantsquid we doesn't have pagination, because every type of transaction (transfer, reward, slash, extrinsic) requested from separate table, but mapped to one.