### PR TITLE
Gate transaction builder tests in CI

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -30,6 +30,11 @@ jobs:
           bash ./scripts/test-todo-debt-audit.sh
           bash ./scripts/audit-todo-debt.sh
 
+      - name: Transaction builder coverage audit
+        run: |
+          bash ./scripts/test-transaction-builder-tests-audit.sh
+          bash ./scripts/audit-transaction-builder-tests.sh
+
       - name: Iroha mobile SDK release asset contract
         env:
           GH_TOKEN: ${{ github.token }}

--- a/scripts/ci/run-pr.sh
+++ b/scripts/ci/run-pr.sh
@@ -23,6 +23,12 @@ if [[ -f "$WORKSPACE_DIR/scripts/audit-todo-debt.sh" ]]; then
   bash "$WORKSPACE_DIR/scripts/audit-todo-debt.sh"
 fi
 
+if [[ -f "$WORKSPACE_DIR/scripts/audit-transaction-builder-tests.sh" ]]; then
+  echo "[run-pr] Running transaction builder coverage audit"
+  bash "$WORKSPACE_DIR/scripts/test-transaction-builder-tests-audit.sh"
+  bash "$WORKSPACE_DIR/scripts/audit-transaction-builder-tests.sh"
+fi
+
 if [[ -f "$WORKSPACE_DIR/scripts/check-iroha-mobile-sdk-release-assets.sh" ]]; then
   echo "[run-pr] Checking Iroha mobile SDK release asset contract"
   bash "$WORKSPACE_DIR/scripts/check-iroha-mobile-sdk-release-assets.sh" --self-test


### PR DESCRIPTION
## Summary
- run the transaction-builder coverage audit in GitHub Actions before the simulator build
- run the same audit pair in scripts/ci/run-pr.sh before dependency and Xcode work

## Validation
- bash scripts/test-transaction-builder-tests-audit.sh
- bash scripts/audit-transaction-builder-tests.sh
- bash -n scripts/ci/run-pr.sh scripts/test-transaction-builder-tests-audit.sh scripts/audit-transaction-builder-tests.sh
- git diff --check

## Release note
This keeps transaction-builder coverage from being dropped from iOS PR validation or CI while the wallet support matrix continues to expand.